### PR TITLE
feat(logging): django admin and api-wide logging of model actions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ---
 
 ## Neste versjon
-
+- ✨ **Logging** av endringer skjer automatisk ved bruk.
 
 ## Versjon 1.0.4 (15.03.2021)
 - ✨ **Filopplastning**. Lagt til støtte for filopplastning til Azure gjennom eget endepunkt. Kun for medlemmer.

--- a/app/career/serializers/weekly_business.py
+++ b/app/career/serializers/weekly_business.py
@@ -1,9 +1,8 @@
-from rest_framework import serializers
-
 from app.career.models import WeeklyBusiness
+from app.common.serializers import BaseModelSerializer
 
 
-class WeeklyBusinessSerializer(serializers.ModelSerializer):
+class WeeklyBusinessSerializer(BaseModelSerializer):
     class Meta:
         model = WeeklyBusiness
         fields = (

--- a/app/career/views/weekly_business.py
+++ b/app/career/views/weekly_business.py
@@ -49,7 +49,9 @@ class WeeklyBusinessViewSet(viewsets.ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         try:
-            serializer = WeeklyBusinessSerializer(data=request.data, partial=True)
+            serializer = WeeklyBusinessSerializer(
+                data=request.data, partial=True, context={"request": request}
+            )
 
             if serializer.is_valid():
                 serializer.save()
@@ -67,7 +69,10 @@ class WeeklyBusinessViewSet(viewsets.ModelViewSet):
         weekly_business = get_object_or_404(WeeklyBusiness, id=pk)
         self.check_object_permissions(self.request, weekly_business)
         serializer = WeeklyBusinessSerializer(
-            weekly_business, data=request.data, partial=True
+            weekly_business,
+            data=request.data,
+            partial=True,
+            context={"request": request},
         )
         try:
             if serializer.is_valid():

--- a/app/common/serializers.py
+++ b/app/common/serializers.py
@@ -1,0 +1,57 @@
+from django.contrib.admin.models import ADDITION, LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.utils.encoding import force_text
+from rest_framework import serializers
+
+
+class LoggerSerializer(serializers.ModelSerializer):
+    """
+    Creates a log entry of the action performed by
+    the current user on the related instance.
+    """
+
+    def create(self, validated_data):
+        """
+        The create function of the ModelSerializer class in Django-REST
+        Framework is being overridden here in order to get access to the
+        object being created.
+        The object instance which is being created is necessary in order
+        to log the action being performed.
+        """
+        user = self._get_user()
+        instance = super().create(validated_data)
+
+        if instance.pk:
+            _log_action(instance=instance, user=user, action="Added")
+
+        return instance
+
+    def _get_user(self):
+        return self.context["request"].user
+
+    def update(self, instance, validated_data):
+        user = self._get_user()
+        instance = super().update(instance, validated_data)
+
+        if instance.pk:
+            _log_action(instance=instance, user=user, action="Updated")
+
+        return instance
+
+
+def _log_action(instance, user, action):
+    message = (
+        f'{action} {force_text(instance._meta.verbose_name)}s "{force_text(instance)}s".',
+    )
+    LogEntry.objects.log_action(
+        user_id=user.pk,
+        content_type_id=ContentType.objects.get_for_model(instance).pk,
+        object_id=instance.pk,
+        object_repr=force_text(instance),
+        action_flag=ADDITION,
+        change_message=message,
+    )
+
+
+class BaseModelSerializer(LoggerSerializer):
+    pass

--- a/app/common/serializers.py
+++ b/app/common/serializers.py
@@ -1,6 +1,6 @@
 from django.contrib.admin.models import ADDITION, LogEntry
 from django.contrib.contenttypes.models import ContentType
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from rest_framework import serializers
 
 
@@ -41,13 +41,13 @@ class LoggerSerializer(serializers.ModelSerializer):
 
 def _log_action(instance, user, action):
     message = (
-        f'{action} {force_text(instance._meta.verbose_name)}s "{force_text(instance)}s".',
+        f'{action} {force_str(instance._meta.verbose_name)}s "{force_str(instance)}s".',
     )
     LogEntry.objects.log_action(
         user_id=user.pk,
         content_type_id=ContentType.objects.get_for_model(instance).pk,
         object_id=instance.pk,
-        object_repr=force_text(instance),
+        object_repr=force_str(instance),
         action_flag=ADDITION,
         change_message=message,
     )

--- a/app/common/serializers.py
+++ b/app/common/serializers.py
@@ -11,13 +11,6 @@ class LoggerSerializer(serializers.ModelSerializer):
     """
 
     def create(self, validated_data):
-        """
-        The create function of the ModelSerializer class in Django-REST
-        Framework is being overridden here in order to get access to the
-        object being created.
-        The object instance which is being created is necessary in order
-        to log the action being performed.
-        """
         user = self._get_user()
         instance = super().create(validated_data)
 

--- a/app/common/serializers.py
+++ b/app/common/serializers.py
@@ -1,4 +1,4 @@
-from django.contrib.admin.models import ADDITION, LogEntry
+from django.contrib.admin.models import ADDITION, CHANGE, LogEntry
 from django.contrib.contenttypes.models import ContentType
 from django.utils.encoding import force_str
 from rest_framework import serializers
@@ -15,7 +15,9 @@ class LoggerSerializer(serializers.ModelSerializer):
         instance = super().create(validated_data)
 
         if instance.pk:
-            _log_action(instance=instance, user=user, action="Added")
+            _log_action(
+                instance=instance, user=user, action="Added", action_flag=ADDITION
+            )
 
         return instance
 
@@ -27,12 +29,14 @@ class LoggerSerializer(serializers.ModelSerializer):
         instance = super().update(instance, validated_data)
 
         if instance.pk:
-            _log_action(instance=instance, user=user, action="Updated")
+            _log_action(
+                instance=instance, user=user, action="Updated", action_flag=CHANGE
+            )
 
         return instance
 
 
-def _log_action(instance, user, action):
+def _log_action(instance, user, action, action_flag):
     message = (
         f'{action} {force_str(instance._meta.verbose_name)}s "{force_str(instance)}s".',
     )
@@ -41,7 +45,7 @@ def _log_action(instance, user, action):
         content_type_id=ContentType.objects.get_for_model(instance).pk,
         object_id=instance.pk,
         object_repr=force_str(instance),
-        action_flag=ADDITION,
+        action_flag=action_flag,
         change_message=message,
     )
 

--- a/app/content/admin/admin.py
+++ b/app/content/admin/admin.py
@@ -1,4 +1,8 @@
 from django.contrib import admin
+from django.contrib.admin.models import DELETION, LogEntry
+from django.urls import reverse
+from django.utils.html import escape
+from django.utils.safestring import mark_safe
 
 from app.content import models
 
@@ -34,3 +38,49 @@ class RegistrationAdmin(admin.ModelAdmin):
 class UserAdmin(admin.ModelAdmin):
     list_display = ("user_id", "first_name", "last_name", "user_class", "user_study")
     search_fields = ("user_id", "first_name", "last_name", "user_class", "user_study")
+
+
+@admin.register(LogEntry)
+class LogEntryAdmin(admin.ModelAdmin):
+    date_hierarchy = "action_time"
+
+    list_filter = ["user", "content_type", "action_flag"]
+
+    search_fields = ["object_repr", "change_message"]
+
+    list_display = [
+        "action_time",
+        "user",
+        "content_type",
+        "object_link",
+        "action_flag",
+    ]
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def object_link(self, obj):
+        if obj.action_flag == DELETION:
+            link = escape(obj.object_repr)
+        else:
+            ct = obj.content_type
+            link = '<a href="%s">%s</a>' % (
+                reverse(
+                    "admin:%s_%s_change" % (ct.app_label, ct.model),
+                    args=[obj.object_id],
+                ),
+                escape(obj.object_repr),
+            )
+        return mark_safe(link)
+
+    object_link.admin_order_field = "object_repr"
+    object_link.short_description = "object"

--- a/app/content/serializers/badge.py
+++ b/app/content/serializers/badge.py
@@ -1,10 +1,10 @@
-from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 
+from app.common.serializers import BaseModelSerializer
 from app.content.models import Badge, User, UserBadge
 
 
-class BadgeSerializer(serializers.ModelSerializer):
+class BadgeSerializer(BaseModelSerializer):
     total_completion_percentage = SerializerMethodField()
 
     class Meta:

--- a/app/content/serializers/category.py
+++ b/app/content/serializers/category.py
@@ -1,9 +1,9 @@
-from rest_framework import serializers
+from app.common.serializers import BaseModelSerializer
 
 from ..models import Category
 
 
-class CategorySerializer(serializers.ModelSerializer):
+class CategorySerializer(BaseModelSerializer):
     class Meta:
         model = Category
         fields = "__all__"  # bad form

--- a/app/content/serializers/cheatsheet.py
+++ b/app/content/serializers/cheatsheet.py
@@ -1,9 +1,9 @@
-from rest_framework import serializers
+from app.common.serializers import BaseModelSerializer
 
 from ..models import Cheatsheet
 
 
-class CheatsheetSerializer(serializers.ModelSerializer):
+class CheatsheetSerializer(BaseModelSerializer):
     class Meta:
         model = Cheatsheet
         fields = [

--- a/app/content/serializers/event.py
+++ b/app/content/serializers/event.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from sentry_sdk import capture_exception
 
+from app.common.serializers import BaseModelSerializer
 from app.content.models import Event, Priority
 from app.content.serializers.priority import PrioritySerializer
 from app.util import EnumUtils
@@ -101,7 +102,7 @@ class EventListSerializer(serializers.ModelSerializer):
         ]
 
 
-class EventCreateAndUpdateSerializer(serializers.ModelSerializer):
+class EventCreateAndUpdateSerializer(BaseModelSerializer):
     registration_priorities = PrioritySerializer(many=True, required=False)
 
     class Meta:

--- a/app/content/serializers/job_post.py
+++ b/app/content/serializers/job_post.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
+from app.common.serializers import BaseModelSerializer
+
 from ..models import JobPost
 
 
-class JobPostSerializer(serializers.ModelSerializer):
+class JobPostSerializer(BaseModelSerializer):
 
     expired = serializers.BooleanField(read_only=True)
 

--- a/app/content/serializers/news.py
+++ b/app/content/serializers/news.py
@@ -1,9 +1,9 @@
-from rest_framework import serializers
+from app.common.serializers import BaseModelSerializer
 
 from ..models import News
 
 
-class NewsSerializer(serializers.ModelSerializer):
+class NewsSerializer(BaseModelSerializer):
     class Meta:
         model = News
         fields = (

--- a/app/content/serializers/notification.py
+++ b/app/content/serializers/notification.py
@@ -1,24 +1,19 @@
-from rest_framework import serializers
-
+from app.common.serializers import BaseModelSerializer
 from app.content.models import Notification
 
 
-class NotificationSerializer(serializers.ModelSerializer):
-    """ Serilaize all the notifcations """
-
+class NotificationSerializer(BaseModelSerializer):
     class Meta:
         model = Notification
         fields = ["id", "message", "read", "created_at"]
 
 
-class UpdateNotificationSerializer(serializers.ModelSerializer):
-    """ Serialize notifications for update """
-
+class UpdateNotificationSerializer(BaseModelSerializer):
     class Meta:
         model = Notification
         fields = ["read"]
 
     def update(self, instance, validated_data):
-        instance.read = validated_data.get("read", instance.read)
-        instance.save()
-        return instance
+        is_read = validated_data.get("read", instance.read)
+
+        return super().update(instance, dict(read=is_read))

--- a/app/content/serializers/page.py
+++ b/app/content/serializers/page.py
@@ -1,10 +1,11 @@
 from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 
+from app.common.serializers import BaseModelSerializer
 from app.content.models import Page
 
 
-class PageSerializer(serializers.ModelSerializer):
+class PageSerializer(BaseModelSerializer):
     children = SerializerMethodField()
     path = SerializerMethodField()
 

--- a/app/content/serializers/priority.py
+++ b/app/content/serializers/priority.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
+from app.common.serializers import BaseModelSerializer
+
 from ..models import Priority
 
 
-class PrioritySerializer(serializers.ModelSerializer):
+class PrioritySerializer(BaseModelSerializer):
     user_class = serializers.IntegerField()
     user_study = serializers.IntegerField()
 

--- a/app/content/serializers/registration.py
+++ b/app/content/serializers/registration.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
+from app.common.serializers import BaseModelSerializer
+
 from ..models import Registration, User
 
 
-class RegistrationSerializer(serializers.ModelSerializer):
+class RegistrationSerializer(BaseModelSerializer):
     user_info = serializers.SerializerMethodField()
 
     class Meta:

--- a/app/content/serializers/short_link.py
+++ b/app/content/serializers/short_link.py
@@ -1,12 +1,12 @@
 import re
 
 from django.core.exceptions import ValidationError
-from rest_framework import serializers
 
+from app.common.serializers import BaseModelSerializer
 from app.content.models import ShortLink
 
 
-class ShortLinkSerializer(serializers.ModelSerializer):
+class ShortLinkSerializer(BaseModelSerializer):
     class Meta:
         model = ShortLink
         fields = ["name", "url"]

--- a/app/content/serializers/user.py
+++ b/app/content/serializers/user.py
@@ -2,6 +2,7 @@ from django.contrib.auth.hashers import make_password
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
+from app.common.serializers import BaseModelSerializer
 from app.content.models import Notification, Registration, User
 from app.content.serializers.badge import BadgeSerializer
 from app.content.serializers.event import EventListSerializer
@@ -82,7 +83,7 @@ class UserSerializer(serializers.ModelSerializer):
         return Notification.objects.filter(user=obj, read=False).count()
 
 
-class UserMemberSerializer(UserSerializer):
+class UserMemberSerializer(UserSerializer, BaseModelSerializer):
     """Serializer for user update to prevent them from updating extra_kwargs fields"""
 
     class Meta(UserSerializer.Meta):

--- a/app/content/serializers/user_badge.py
+++ b/app/content/serializers/user_badge.py
@@ -1,9 +1,10 @@
 from rest_framework import serializers
 
+from app.common.serializers import BaseModelSerializer
 from app.content.models import UserBadge
 
 
-class UserBadgeSerializer(serializers.ModelSerializer):
+class UserBadgeSerializer(BaseModelSerializer):
     user = serializers.SerializerMethodField()
     badge = serializers.SerializerMethodField()
 

--- a/app/content/views/cheatsheet.py
+++ b/app/content/views/cheatsheet.py
@@ -57,7 +57,9 @@ class CheatsheetViewSet(viewsets.ModelViewSet):
     def create(self, request, *args, **kwargs):
         """Creates a new cheatsheet """
         if is_admin_user(request):
-            serializer = CheatsheetSerializer(data=self.request.data)
+            serializer = CheatsheetSerializer(
+                data=self.request.data, context={"request": request}
+            )
             if serializer.is_valid():
                 serializer.save()
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -74,7 +76,9 @@ class CheatsheetViewSet(viewsets.ModelViewSet):
         try:
             cheatsheet = self.get_object()
             if is_admin_user(request):
-                serializer = CheatsheetSerializer(cheatsheet, data=request.data)
+                serializer = CheatsheetSerializer(
+                    cheatsheet, data=request.data, context={"request": request}
+                )
                 if serializer.is_valid():
                     serializer.save()
                     return Response(serializer.data, status=status.HTTP_200_OK)

--- a/app/content/views/event.py
+++ b/app/content/views/event.py
@@ -70,7 +70,7 @@ class EventViewSet(viewsets.ModelViewSet):
             event = Event.objects.get(pk=pk)
             self.check_object_permissions(self.request, event)
             serializer = EventCreateAndUpdateSerializer(
-                event, data=request.data, partial=True
+                event, data=request.data, partial=True, context={"request": request}
             )
 
             if serializer.is_valid():
@@ -90,8 +90,9 @@ class EventViewSet(viewsets.ModelViewSet):
             )
 
     def create(self, request, *args, **kwargs):
-        """Create an event."""
-        serializer = EventCreateAndUpdateSerializer(data=request.data)
+        serializer = EventCreateAndUpdateSerializer(
+            data=request.data, context={"request": request}
+        )
 
         if serializer.is_valid():
             event = serializer.save()

--- a/app/content/views/notification.py
+++ b/app/content/views/notification.py
@@ -27,7 +27,9 @@ class NotificationViewSet(viewsets.ModelViewSet):
     def update(self, request, pk):
         notification = get_object_or_404(Notification, id=pk)
         self.check_object_permissions(self.request, notification)
-        serializer = UpdateNotificationSerializer(notification, data=request.data)
+        serializer = UpdateNotificationSerializer(
+            notification, data=request.data, context={"request": request}
+        )
         if serializer.is_valid():
             notification = serializer.save()
             serializer = NotificationSerializer(notification)

--- a/app/content/views/page.py
+++ b/app/content/views/page.py
@@ -65,7 +65,9 @@ class PageViewSet(viewsets.ModelViewSet):
         try:
             parent = Page.get_by_path(request.data["path"])
             page = Page(parent=parent)
-            serializer = PageSerializer(page, data=request.data)
+            serializer = PageSerializer(
+                page, data=request.data, context={"request": request}
+            )
             if serializer.is_valid():
                 serializer.save()
                 return Response(serializer.data, status=status.HTTP_200_OK)
@@ -94,7 +96,9 @@ class PageViewSet(viewsets.ModelViewSet):
         try:
             page = self.get_page_from_tree()
             page.parent = Page.get_by_path(request.data["path"])
-            serializer = PageSerializer(page, data=request.data)
+            serializer = PageSerializer(
+                page, data=request.data, context={"request": request}
+            )
             if serializer.is_valid():
                 serializer.save()
                 return Response(serializer.data, status=status.HTTP_200_OK)

--- a/app/content/views/short_link.py
+++ b/app/content/views/short_link.py
@@ -27,7 +27,9 @@ class ShortLinkViewSet(viewsets.ModelViewSet):
 
     def create(self, request):
         user = get_object_or_404(User, user_id=request.id)
-        serializer = ShortLinkSerializer(data=request.data)
+        serializer = ShortLinkSerializer(
+            data=request.data, context={"request": request}
+        )
         if serializer.is_valid():
             try:
                 serializer.save(user=user)

--- a/app/fixture.json
+++ b/app/fixture.json
@@ -149,7 +149,9 @@
       "fields": {
          "user": "index",
          "message": "Dette er første notifikasjon ever!!",
-         "read": true
+         "read": true,
+         "created_at": "2020-10-01T18:54:36.940Z",
+         "updated_at": "2020-10-01T18:54:36.940Z"
       }
    },
    {
@@ -158,7 +160,9 @@
       "fields": {
          "user": "index",
          "message": "Du har fått plass på Pirater sier Arr",
-         "read": true
+         "read": true,
+         "created_at": "2020-10-01T18:54:36.940Z",
+         "updated_at": "2020-10-01T18:54:36.940Z"
       }
    },
    {

--- a/app/forms/serializers/forms.py
+++ b/app/forms/serializers/forms.py
@@ -3,10 +3,11 @@ from rest_framework import serializers
 
 from rest_polymorphic.serializers import PolymorphicSerializer
 
+from app.common.serializers import BaseModelSerializer
 from app.forms.models import EventForm, Field, Form, Option
 
 
-class OptionSerializer(serializers.ModelSerializer):
+class OptionSerializer(BaseModelSerializer):
     id = serializers.UUIDField(read_only=False, required=False)
 
     class Meta:
@@ -17,7 +18,7 @@ class OptionSerializer(serializers.ModelSerializer):
         )
 
 
-class FieldSerializer(serializers.ModelSerializer):
+class FieldSerializer(BaseModelSerializer):
     options = OptionSerializer(many=True, required=False, allow_null=True)
     id = serializers.UUIDField(read_only=False, required=False)
 
@@ -32,7 +33,7 @@ class FieldSerializer(serializers.ModelSerializer):
         )
 
 
-class FormSerializer(serializers.ModelSerializer):
+class FormSerializer(BaseModelSerializer):
     fields = FieldSerializer(many=True, required=False, allow_null=True)
 
     class Meta:

--- a/app/forms/serializers/submission.py
+++ b/app/forms/serializers/submission.py
@@ -1,5 +1,4 @@
-from rest_framework import serializers
-
+from app.common.serializers import BaseModelSerializer
 from app.content.serializers import UserInAnswerSerializer
 from app.forms.models import Answer, Submission
 from app.forms.serializers import (
@@ -9,7 +8,7 @@ from app.forms.serializers import (
 )
 
 
-class AnswerSerializer(serializers.ModelSerializer):
+class AnswerSerializer(BaseModelSerializer):
     field = FieldInAnswerSerializer(read_only=True)
     selected_options = OptionSerializer(read_only=True)
 
@@ -18,7 +17,7 @@ class AnswerSerializer(serializers.ModelSerializer):
         fields = ["id", "field", "selected_options", "answer_text"]
 
 
-class SubmissionSerializer(serializers.ModelSerializer):
+class SubmissionSerializer(BaseModelSerializer):
     form = FormInSubmissionSerializer(read_only=True)
     user = UserInAnswerSerializer(read_only=True)
     answer = AnswerSerializer(read_only=True)

--- a/app/group/serializers/group.py
+++ b/app/group/serializers/group.py
@@ -1,22 +1,19 @@
 from rest_framework import serializers
 
-from app.common.enums import MembershipType
 from app.group.models import Group, Membership
+from app.common.serializers import BaseModelSerializer
 
 
 class DefaultGroupSerializer(serializers.ModelSerializer):
-    """Serizlier for Groups with lookup by slug field and only return the name of the group"""
-
     class Meta:
         model = Group
         fields = ("name",)
 
 
-class GroupSerializer(serializers.ModelSerializer):
-    """Serizlier for Groups with lookup by slug field"""
-
+class GroupSerializer(BaseModelSerializer):
+    
     leader = serializers.SerializerMethodField()
-
+    
     class Meta:
         model = Group
         lookup_field = "slug"

--- a/app/group/serializers/group.py
+++ b/app/group/serializers/group.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 
-from app.group.models import Group, Membership
+from app.common.enums import MembershipType
 from app.common.serializers import BaseModelSerializer
+from app.group.models import Group, Membership
 
 
 class DefaultGroupSerializer(serializers.ModelSerializer):
@@ -11,9 +12,9 @@ class DefaultGroupSerializer(serializers.ModelSerializer):
 
 
 class GroupSerializer(BaseModelSerializer):
-    
+
     leader = serializers.SerializerMethodField()
-    
+
     class Meta:
         model = Group
         lookup_field = "slug"

--- a/app/group/serializers/membership.py
+++ b/app/group/serializers/membership.py
@@ -1,11 +1,12 @@
 from rest_framework import serializers
 
+from app.common.serializers import BaseModelSerializer
 from app.content.serializers.user import DefaultUserSerializer, UserSerializer
 from app.group.models import Membership, MembershipHistory
 from app.group.serializers.group import DefaultGroupSerializer, GroupSerializer
 
 
-class MembershipSerializer(serializers.ModelSerializer):
+class MembershipSerializer(BaseModelSerializer):
     user = DefaultUserSerializer(read_only=True)
     group = DefaultGroupSerializer(read_only=True)
 

--- a/app/group/views/group.py
+++ b/app/group/views/group.py
@@ -39,7 +39,9 @@ class GroupViewSet(viewsets.ModelViewSet):
         """Updates a spesific group by slug"""
         try:
             group = self.get_object()
-            serializer = GroupSerializer(group, data=request.data, partial=True)
+            serializer = GroupSerializer(
+                group, data=request.data, partial=True, context={"request": request}
+            )
             if serializer.is_valid():
                 serializer.save()
                 return Response(data=serializer.data, status=status.HTTP_200_OK)
@@ -54,7 +56,9 @@ class GroupViewSet(viewsets.ModelViewSet):
         try:
             slug = request.data["slug"]
             group = Group.objects.get_or_create(slug=slug)
-            serializer = GroupSerializer(group[0], data=request.data)
+            serializer = GroupSerializer(
+                group[0], data=request.data, context={"request": request}
+            )
             if serializer.is_valid():
                 serializer.save()
                 return Response(data=serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Proposed changes
Implement automatic logging of actions taken on models either through the API or django admin. The former currently only supports logging upon creation/update. Implemented using Django's built-in LogEntry model. 

These log entries are immutable to preserve an accurate log history.

![image](https://user-images.githubusercontent.com/35424810/111911811-48a57680-8a67-11eb-8999-85eefb729936.png)


Issue number: closes #37 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments
The logging via api usage happens in LoggerSerializer, but I chose to inherit from a BaseModelSerializer instead in case we need to alter inheritance in the future.