### PR TITLE
refactor(docker): use python-slim-buster and clean up dockerfile + compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,20 @@
-FROM python:3.6-alpine
+FROM python:3.6-slim-buster
 ENV PYTHONUNBUFFERED 1
 
-WORKDIR /usr/src
+RUN apt-get update \
+  # dependencies for building Python packages
+  && apt-get install -y build-essential \
+  # mysqlclient dependencies
+  && apt-get install -y default-libmysqlclient-dev \
+  # cleaning up unused files
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --upgrade pip && \
-    apk add --no-cache mariadb-dev
-
+# Requirements are installed here to ensure they will be cached.
 COPY requirements.txt ./
+RUN pip install -r requirements.txt
 
-# Install required python packages
-RUN apk --update add --no-cache --virtual .build-deps gcc musl-dev python3-dev libffi-dev openssl-dev cargo py-pip linux-headers libc-dev build-base && \
-      pip install --upgrade pip && \
-      pip install -r requirements.txt && \
-      rm -rf ~/.cache/pip && \
-    apk del .build-deps
-
-COPY . .
-
-VOLUME /usr/src/app/volume
+WORKDIR /app
 
 EXPOSE 8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - MYSQL_USER=dev
       - MYSQL_PASSWORD=password
       - MYSQL_DATABASE=nettside-dev
+
   phpmyadmin:
     depends_on:
       - db
@@ -22,20 +23,12 @@ services:
     environment:
       PMA_HOST: db
       MYSQL_ROOT_PASSWORD: password
-  celery:
+
+  web: &web
     env_file:
       - .env
     build: .
-    container_name: celery
-    command: celery -A app worker -l info
-    volumes:
-      - .:/app:z
-    depends_on:
-      - db
-  web:
-    env_file:
-      - .env
-    build: .
+    image: web
     container_name: web
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
@@ -44,3 +37,10 @@ services:
       - "8000:8000"
     depends_on:
       - db
+
+  celery:
+    <<: *web
+    image: celery
+    container_name: celery
+    command: celery -A app worker -l info
+    ports: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     container_name: celery
     command: celery -A app worker -l info
     volumes:
-      - .:/usr/src/
+      - .:/app:z
     depends_on:
       - db
   web:
@@ -39,7 +39,7 @@ services:
     container_name: web
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - .:/usr/src/
+      - .:/app:z
     ports:
       - "8000:8000"
     depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ azure-storage-blob == 12.8.0
 
 # Django
 # ------------------------------------------------------------------------------
+Django~=3.1.0
 django-enumchoicefield
 django-dotenv
 django-filter


### PR DESCRIPTION
## Proposed changes
Much faster Docker builds.

Use python3.6-slim-buster base image in Dockerfile to speed up build and avoid pitfalls described [here](https://pythonspeed.com/articles/alpine-docker-python/) which includes slower build times for python, potentially obscure bugs, larger images and more work. 

Issue number: No issue


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments
With Alpine Linux you need to compile all the C code in every Python package that you use which is one of the reasons it is slower.
