### PR TITLE
fix(azure): don't deploy to webapp through action

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -3,7 +3,7 @@ name: Deploy to Azure development
 on:
   push:
     branches:
-      - dev
+      - azure
   workflow_dispatch:
 
 jobs:
@@ -42,11 +42,3 @@ jobs:
         tags: leptondevregistry.azurecr.io/lepton:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
-
-    - name: Deploy to Azure Web App
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: 'lepton-dev-api'
-        slot-name: 'production'
-        publish-profile: ${{ secrets.APP_SERVICE_PUBLISH_PROFILE_DEV }}
-        images: 'leptondevregistry.azurecr.io/lepton:latest'

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -3,7 +3,7 @@ name: Deploy to Azure development
 on:
   push:
     branches:
-      - azure
+      - azure-fix-deploy
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -3,7 +3,7 @@ name: Deploy to Azure development
 on:
   push:
     branches:
-      - azure-fix-deploy
+      - dev
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Proposed changes
There's an issue in Azure where the App Service configuration is changed on CI/CD push and I suspect that's because we manually push the image to the webapp. Therefore this removes the push through Github Actions and we instead use the "Countinuous deployment"-setting in App Service Deployment configuration which automatically updates when a new image is pushed to the selected container registry.

Issue number: closes #


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
