### PR TITLE
fix(docker): change docker-compose volumes mapping to match Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     container_name: web
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
-      - .:/app:z
+      - .:/usr/src/
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Proposed changes
Docker-compose was not able to pick up code changes due to a mismatch in the volumes mounts. This fix reverts the volumes mapping back to what we previously had.

Issue number: No issue


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments
