### PR TITLE
fix(event): change usage of django orm for event retreival to using drf's self.get_object to handle invalid inputs

### DIFF
--- a/app/content/views/event.py
+++ b/app/content/views/event.py
@@ -48,7 +48,7 @@ class EventViewSet(viewsets.ModelViewSet):
     def retrieve(self, request, pk):
         """Return detailed information about the event with the specified pk."""
         try:
-            event = Event.objects.get(pk=pk)
+            event = self.get_object()
             if is_admin_user(request):
                 serializer = EventAdminSerializer(
                     event, context={"request": request}, many=False
@@ -67,7 +67,7 @@ class EventViewSet(viewsets.ModelViewSet):
     def update(self, request, pk):
         """Update the event with the specified pk."""
         try:
-            event = Event.objects.get(pk=pk)
+            event = self.get_object()
             self.check_object_permissions(self.request, event)
             serializer = EventCreateAndUpdateSerializer(
                 event, data=request.data, partial=True, context={"request": request}


### PR DESCRIPTION
## Proposed changes
The endpoints where resulting in 500 Internal Server Error when an invalid id was passed to the uri /events/<pk>

Issue number: closes #69 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
