### PR TITLE
feat(group-permissions): added field on group serializer to see if a user has permissions

### DIFF
--- a/app/group/models/group.py
+++ b/app/group/models/group.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Permission
 from django.db import models
 from django.utils.text import slugify
 
@@ -14,9 +13,6 @@ class Group(OptionalImage, BaseModel, BasePermissionModel):
 
     write_access = [AdminGroup.HS, AdminGroup.INDEX, AdminGroup.NOK, AdminGroup.PROMO]
     name = models.CharField(max_length=50)
-    permissions = models.ManyToManyField(
-        Permission, related_name="groups_permissions", blank=True
-    )
     slug = models.SlugField(max_length=50, primary_key=True)
     description = models.TextField(max_length=1000, null=True, blank=True)
     contact_email = models.EmailField(max_length=200, null=True, blank=True)

--- a/app/group/serializers/group.py
+++ b/app/group/serializers/group.py
@@ -10,7 +10,7 @@ from app.group.models import Group, Membership
 class DefaultGroupSerializer(serializers.ModelSerializer):
     class Meta:
         model = Group
-        fields = ("name","slug")
+        fields = ("name", "slug")
 
 
 class GroupSerializer(BaseModelSerializer):

--- a/app/group/serializers/group.py
+++ b/app/group/serializers/group.py
@@ -1,10 +1,11 @@
 from rest_framework import serializers
 
+from dry_rest_permissions.generics import DRYPermissionsField
+
 from app.common.enums import MembershipType
 from app.common.serializers import BaseModelSerializer
 from app.group.models import Group, Membership
 
-from dry_rest_permissions.generics import DRYGlobalPermissionsField
 
 class DefaultGroupSerializer(serializers.ModelSerializer):
     class Meta:
@@ -15,8 +16,7 @@ class DefaultGroupSerializer(serializers.ModelSerializer):
 class GroupSerializer(BaseModelSerializer):
 
     leader = serializers.SerializerMethodField()
-    permissions = DRYGlobalPermissionsField(actions=["write", "read"])
-
+    permissions = DRYPermissionsField(actions=["write", "read"])
 
     class Meta:
         model = Group

--- a/app/group/serializers/group.py
+++ b/app/group/serializers/group.py
@@ -4,6 +4,7 @@ from app.common.enums import MembershipType
 from app.common.serializers import BaseModelSerializer
 from app.group.models import Group, Membership
 
+from dry_rest_permissions.generics import DRYGlobalPermissionsField
 
 class DefaultGroupSerializer(serializers.ModelSerializer):
     class Meta:
@@ -14,6 +15,8 @@ class DefaultGroupSerializer(serializers.ModelSerializer):
 class GroupSerializer(BaseModelSerializer):
 
     leader = serializers.SerializerMethodField()
+    permissions = DRYGlobalPermissionsField(actions=["write", "read"])
+
 
     class Meta:
         model = Group

--- a/app/group/serializers/group.py
+++ b/app/group/serializers/group.py
@@ -10,7 +10,7 @@ from app.group.models import Group, Membership
 class DefaultGroupSerializer(serializers.ModelSerializer):
     class Meta:
         model = Group
-        fields = ("name",)
+        fields = ("name","slug")
 
 
 class GroupSerializer(BaseModelSerializer):

--- a/app/settings.py
+++ b/app/settings.py
@@ -80,8 +80,8 @@ INSTALLED_APPS = [
     # Our apps
     "app.content",
     "app.common",
-    "app.authentication",
     "app.group",
+    "app.authentication",
     "app.util",
     "app.career",
     "app.forms",


### PR DESCRIPTION
## Proposed changes
Added a field on group serializer to see if a user has permissions to change that group or not
![Screenshot from 2021-04-17 15-00-59](https://user-images.githubusercontent.com/60223374/115114223-609ce700-9f8e-11eb-83fd-1f67d1520f2c.png)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
