### PR TITLE
fix(celery): disable rabbitmq heartbeats

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,4 +11,4 @@ services:
   celery:
     image: leptondevregistry.azurecr.io/lepton:latest
     container_name: celery
-    command: celery -A app worker -l info
+    command: celery -A app worker -l info --without-heartbeat --without-gossip --without-mingle

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,4 +11,4 @@ services:
   celery:
     image: leptonregistry.azurecr.io/lepton:latest
     container_name: celery
-    command: celery -A app worker -l info
+    command: celery -A app worker -l info --without-heartbeat --without-gossip --without-mingle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,5 +42,5 @@ services:
     <<: *web
     image: celery
     container_name: celery
-    command: celery -A app worker -l info
+    command: celery -A app worker -l info --without-heartbeat --without-gossip --without-mingle
     ports: []


### PR DESCRIPTION
## Proposed changes
Turns off heartbeats, mingle and gossip messages from celery to our RabbitMQ hosted at CloudAMQP. Config has been updated in Azure. We should wait merging this until we have confirmed that the updated config fixes the issue. Shouldn't take more than a day to check.

Issue number: closes #110 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
