### PR TITLE
fix(registrations): users can set allow-photo to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+- 🦟 **Påmelding**. Fikset bug der brukere ikke kunne avslå å bli avbildet på arrangementer.
+
 ## Versjon 1.0.7 (26.04.2021)
 - ⚡ **Azure**. Satt opp produksjon i Azure og automatisk oppdatering ved push til master.
 - ✨ **Endring i permissions**. Endret hvordan vi håndterer tillatelser på nettsiden til å bruke våre nye grupper.

--- a/app/content/views/registration.py
+++ b/app/content/views/registration.py
@@ -47,7 +47,7 @@ class RegistrationViewSet(APIRegistrationErrorsMixin, viewsets.ModelViewSet):
         current_user = request.user
 
         registration = Registration.objects.get_or_create(
-            user=current_user, event=event
+            user=current_user, event=event, allow_photo=request.data["allow_photo"]
         )[0]
         registration_serializer = RegistrationSerializer(
             registration, context={"user": registration.user}

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -188,7 +188,6 @@ def test_create_as_member_registers_themselves(member, event):
     assert actual_user_id == member.user_id
 
 
-
 @pytest.mark.django_db
 def test_create_as_member_registers_themselves_not_allow_photo(member, event):
     """A member should be able to create a registration and not allow photo."""

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -199,7 +199,7 @@ def test_create_as_member_registers_themselves_not_allow_photo(member, event):
     response = client.post(url, data=data)
 
     assert response.status_code == status.HTTP_201_CREATED
-    assert response.json().get("allow_photo") == False
+    assert not response.json().get("allow_photo")
 
 
 @pytest.mark.django_db

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -29,7 +29,7 @@ def _get_registration_post_data(user, event):
     return {
         "user_id": user.user_id,
         "event": event.pk,
-        "allow_photo": False,
+        "allow_photo": True,
     }
 
 
@@ -186,6 +186,21 @@ def test_create_as_member_registers_themselves(member, event):
 
     assert response.status_code == status.HTTP_201_CREATED
     assert actual_user_id == member.user_id
+
+
+
+@pytest.mark.django_db
+def test_create_as_member_registers_themselves_not_allow_photo(member, event):
+    """A member should be able to create a registration and not allow photo."""
+    data = _get_registration_post_data(member, event)
+    data["allow_photo"] = False
+    client = get_api_client(user=member)
+
+    url = _get_registration_url(event=event)
+    response = client.post(url, data=data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json().get("allow_photo") == False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Proposed changes
Allows users to set allow_photo to false onregistration to event. Added test

Issue number: closes #114 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
