### PR TITLE
refactor(user): improve speed on list request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ---
 
 ## Neste versjon
-- ⚡ **Forbedre hastighet**. Stoppet sjekk av om bruker er medlem av TIHLDE ved hver uthenting, heller kun ved spesifikk forespørsel.
+- ⚡ **Brukere**. Fjernet felter fra brukere som hentes ut i liste, slik at forespørselen går raskere.
 
 ## Versjon 1.0.7 (26.04.2021)
 - ⚡ **Azure**. Satt opp produksjon i Azure og automatisk oppdatering ved push til master.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+- ⚡ **Forbedre hastighet**. Stoppet sjekk av om bruker er medlem av TIHLDE ved hver uthenting, heller kun ved spesifikk forespørsel.
+
 ## Versjon 1.0.7 (26.04.2021)
 - ⚡ **Azure**. Satt opp produksjon i Azure og automatisk oppdatering ved push til master.
 - ✨ **Endring i permissions**. Endret hvordan vi håndterer tillatelser på nettsiden til å bruke våre nye grupper.

--- a/app/authentication/views.py
+++ b/app/authentication/views.py
@@ -5,11 +5,12 @@ from rest_framework.response import Response
 
 from sentry_sdk import capture_exception
 
+from app.common.enums import Groups
 from app.common.permissions import IsDev, IsHS
 
-from ..content.models.user import User
-from .exceptions import APIAuthUserDoesNotExist
-from .serializers import AuthSerializer, MakeUserSerializer
+from app.content.models.user import User
+from app.authentication.exceptions import APIAuthUserDoesNotExist
+from app.authentication.serializers import AuthSerializer, MakeUserSerializer
 
 
 @api_view(["POST"])
@@ -27,7 +28,7 @@ def login(request):
     user = _try_to_get_user(user_id=user_id)
 
     if user.check_password(password):
-        if user.is_TIHLDE_member:
+        if user.memberships.filter(group__slug=Groups.TIHLDE).exists():
             try:
                 token = Token.objects.get(user_id=user_id).key
                 return Response({"token": token}, status=status.HTTP_200_OK)

--- a/app/authentication/views.py
+++ b/app/authentication/views.py
@@ -5,12 +5,11 @@ from rest_framework.response import Response
 
 from sentry_sdk import capture_exception
 
-from app.common.enums import Groups
-from app.common.permissions import IsDev, IsHS
-
-from app.content.models.user import User
 from app.authentication.exceptions import APIAuthUserDoesNotExist
 from app.authentication.serializers import AuthSerializer, MakeUserSerializer
+from app.common.enums import Groups
+from app.common.permissions import IsDev, IsHS
+from app.content.models.user import User
 
 
 @api_view(["POST"])

--- a/app/authentication/views.py
+++ b/app/authentication/views.py
@@ -7,7 +7,6 @@ from sentry_sdk import capture_exception
 
 from app.authentication.exceptions import APIAuthUserDoesNotExist
 from app.authentication.serializers import AuthSerializer, MakeUserSerializer
-from app.common.enums import Groups
 from app.common.permissions import IsDev, IsHS
 from app.content.models.user import User
 
@@ -27,7 +26,7 @@ def login(request):
     user = _try_to_get_user(user_id=user_id)
 
     if user.check_password(password):
-        if user.memberships.filter(group__slug=Groups.TIHLDE).exists():
+        if user.is_TIHLDE_member:
             try:
                 token = Token.objects.get(user_id=user_id).key
                 return Response({"token": token}, status=status.HTTP_200_OK)

--- a/app/content/filters/user.py
+++ b/app/content/filters/user.py
@@ -19,8 +19,6 @@ class UserFilter(FilterSet):
         fields = ["user_class", "user_study", "is_TIHLDE_member"]
 
     def filter_is_TIHLDE_member(self, queryset, name, value):
-        if value is True:
-            return queryset.filter(memberships__group__slug=Groups.TIHLDE)
-        elif value is False:
+        if value is False:
             return queryset.exclude(memberships__group__slug=Groups.TIHLDE)
-        return queryset
+        return queryset.filter(memberships__group__slug=Groups.TIHLDE)

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -95,7 +95,6 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
     def is_TIHLDE_member(self):
         return self.memberships.filter(group__slug=Groups.TIHLDE).exists()
 
-
     def has_perm(self, perm, obj=None):
         return self.is_superuser
 

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -10,7 +10,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from rest_framework.authtoken.models import Token
 
-from app.common.enums import AdminGroup, MembershipType
+from app.common.enums import AdminGroup, Groups, MembershipType
 from app.common.permissions import check_has_access
 from app.util.models import BaseModel, OptionalImage
 from app.util.utils import disable_for_loaddata
@@ -90,6 +90,11 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
 
     def __str__(self):
         return f"User - {self.user_id}: {self.first_name} {self.last_name}"
+
+    @property
+    def is_TIHLDE_member(self):
+        return self.memberships.filter(group__slug=Groups.TIHLDE).exists()
+
 
     def has_perm(self, perm, obj=None):
         return self.is_superuser

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -10,7 +10,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from rest_framework.authtoken.models import Token
 
-from app.common.enums import AdminGroup, Groups, MembershipType
+from app.common.enums import AdminGroup, MembershipType
 from app.common.permissions import check_has_access
 from app.util.models import BaseModel, OptionalImage
 from app.util.utils import disable_for_loaddata
@@ -90,10 +90,6 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
 
     def __str__(self):
         return f"User - {self.user_id}: {self.first_name} {self.last_name}"
-
-    @property
-    def is_TIHLDE_member(self):
-        return self.memberships.filter(group__slug=Groups.TIHLDE).exists()
 
     def has_perm(self, perm, obj=None):
         return self.is_superuser

--- a/app/content/serializers/__init__.py
+++ b/app/content/serializers/__init__.py
@@ -20,6 +20,7 @@ from app.content.serializers.user import (
     UserAdminSerializer,
     UserCreateSerializer,
     UserInAnswerSerializer,
+    UserListSerializer,
     UserMemberSerializer,
     UserSerializer,
 )

--- a/app/content/serializers/user.py
+++ b/app/content/serializers/user.py
@@ -29,7 +29,6 @@ class DefaultUserSerializer(serializers.ModelSerializer):
 
 class UserSerializer(serializers.ModelSerializer):
     events = serializers.SerializerMethodField()
-    groups = serializers.SerializerMethodField()
     badges = serializers.SerializerMethodField()
     unread_notifications = serializers.SerializerMethodField()
     permissions = DRYGlobalPermissionsField(actions=["write", "read"])
@@ -52,7 +51,6 @@ class UserSerializer(serializers.ModelSerializer):
             "tool",
             "app_token",
             "events",
-            "groups",
             "badges",
             "unread_notifications",
             "permissions",
@@ -79,10 +77,6 @@ class UserSerializer(serializers.ModelSerializer):
         badges = [user_badge.badge for user_badge in user_badges]
         return BadgeSerializer(badges, many=True).data
 
-    def get_groups(self, obj):
-        """ Lists all groups a user is a member of """
-        return [group.name for group in obj.groups.all()]
-
     def get_unread_notifications(self, obj):
         """ Counts all unread notifications and returns the count """
         return Notification.objects.filter(user=obj, read=False).count()
@@ -94,6 +88,24 @@ class UserSerializer(serializers.ModelSerializer):
         ]
         return StrikeSerializer(active_strikes, many=True).data
 
+class UserListSerializer(UserSerializer):
+
+    class Meta:
+        model = User
+        fields = (
+            "user_id",
+            "first_name",
+            "last_name",
+            "image",
+            "email",
+            "cell",
+            "gender",
+            "user_class",
+            "user_study",
+            "allergy",
+            "tool",
+            "strikes",
+        )
 
 class UserMemberSerializer(UserSerializer):
     """Serializer for user update to prevent them from updating extra_kwargs fields"""

--- a/app/content/serializers/user.py
+++ b/app/content/serializers/user.py
@@ -88,8 +88,8 @@ class UserSerializer(serializers.ModelSerializer):
         ]
         return StrikeSerializer(active_strikes, many=True).data
 
-class UserListSerializer(UserSerializer):
 
+class UserListSerializer(UserSerializer):
     class Meta:
         model = User
         fields = (
@@ -106,6 +106,7 @@ class UserListSerializer(UserSerializer):
             "tool",
             "strikes",
         )
+
 
 class UserMemberSerializer(UserSerializer):
     """Serializer for user update to prevent them from updating extra_kwargs fields"""

--- a/app/content/serializers/user.py
+++ b/app/content/serializers/user.py
@@ -51,7 +51,6 @@ class UserSerializer(serializers.ModelSerializer):
             "allergy",
             "tool",
             "app_token",
-            "is_TIHLDE_member",
             "events",
             "groups",
             "badges",
@@ -106,7 +105,6 @@ class UserMemberSerializer(UserSerializer):
             "first_name",
             "last_name",
             "email",
-            "is_TIHLDE_member",
         )
 
 
@@ -119,7 +117,6 @@ class UserAdminSerializer(serializers.ModelSerializer):
             "user_id",
             "first_name",
             "last_name",
-            "is_TIHLDE_member",
         )
         read_only_fields = (
             "user_id",

--- a/app/content/views/user.py
+++ b/app/content/views/user.py
@@ -12,6 +12,7 @@ from app.content.models import User
 from app.content.serializers import (
     UserAdminSerializer,
     UserCreateSerializer,
+    UserListSerializer,
     UserMemberSerializer,
     UserSerializer,
 )
@@ -28,6 +29,12 @@ class UserViewSet(viewsets.ModelViewSet):
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
     filterset_class = UserFilter
     search_fields = ["user_id", "first_name", "last_name"]
+
+    def get_serializer_class(self):
+        if hasattr(self, "action") and self.action == "list":
+            return UserListSerializer
+        return super().get_serializer_class()
+
 
     def retrieve(self, request, *args, **kwargs):
         try:

--- a/app/content/views/user.py
+++ b/app/content/views/user.py
@@ -35,7 +35,6 @@ class UserViewSet(viewsets.ModelViewSet):
             return UserListSerializer
         return super().get_serializer_class()
 
-
     def retrieve(self, request, *args, **kwargs):
         try:
             user = request.user

--- a/app/fixture.json
+++ b/app/fixture.json
@@ -1081,6 +1081,18 @@
         "membership_type": "LEADER",
         "expiration_date": null
     }
+},
+{
+    "model": "group.membership",
+    "pk": 9,
+    "fields": {
+        "created_at": "2021-05-01T10:02:30.243Z",
+        "updated_at": "2021-05-01T10:02:30.243Z",
+        "user": "index",
+        "group": "tihlde",
+        "membership_type": "MEMBER",
+        "expiration_date": "2029-05-01"
+    }
 }
 
 ]


### PR DESCRIPTION
## Proposed changes
- First removed the `is_TIHLDE_member` property in a try to increase speed/performance, but without luck
- The solution seems to be removing permissions from the serializer. I therefore created a new UserListSerializer without "permissions".
- Removed "app_token", "events", "badges", "groups", "unread_notifications" and "home_busstop" fields as well, couse I can't see why an admin user should need to see that info. Can discuss wether more fields also should be removed from the serializer.
- PR in Kvark will be created as well to support these changes

Issue number: closes #102 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
