### PR TITLE
fix(reset-password): update reset password domain to api.tihlde.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## Neste versjon
 - 🦟 **Påmelding**. Fikset bug der brukere ikke kunne avslå å bli avbildet på arrangementer.
-
+- 🦟 **Tilbakestilling av passord** tar brukeren til riktig side fremfor en som ikke finnes.
 ## Versjon 1.0.7 (26.04.2021)
 - ⚡ **Azure**. Satt opp produksjon i Azure og automatisk oppdatering ved push til master.
 - ✨ **Endring i permissions**. Endret hvordan vi håndterer tillatelser på nettsiden til å bruke våre nye grupper.
@@ -25,7 +25,7 @@
 - 🦟 **Oppdatert arrangement**. Fikset bug der det ikke var mulig å oppdatere arrangement.
 - ✨ **Azure**. Satt opp dev-miljø i Azure for å migrere vekk fra Drift og til skyen.
 - ✨ **Venteliste nummer**. Henter nå ut hvilken plass du er på i ventelisten
-- ✨ **Refusjons skjema**. Lagt til mulighet for å sende refusjons skjema rett til økonomiansvarlig, med kvittering. 
+- ✨ **Refusjons skjema**. Lagt til mulighet for å sende refusjons skjema rett til økonomiansvarlig, med kvittering.
 
 ## Versjon 1.0.5 (24.03.2021)
 - 🦟 **Opprett arrangement**. Fikset feil der det ikke var mulig å opprette et arrangement.

--- a/app/settings.py
+++ b/app/settings.py
@@ -23,7 +23,7 @@ from app.common.enums import EnvironmentOptions
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-DOMAIN = "tihlde.org/"
+DOMAIN = "api.tihlde.org"
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/


### PR DESCRIPTION
## Proposed changes
Update domain setting to `api.tihlde.org` in order to fix issue where the reset-password link would take the user to the old api-domain. 

Issue number: closes #118 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments
