### PR TITLE
fix(permissions): let hs activate new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 
 ## Neste versjon
+- 🦟 **Tilganger**. Fikset bug der HS ikke hadde tilgang til å aktivere nye brukere.
 
 ## Versjon 1.0.8 (01.05.2021)
 - ⚡ **Brukere**. Fjernet felter fra brukere som hentes ut i liste, slik at forespørselen går raskere.

--- a/app/authentication/serializers/__init__.py
+++ b/app/authentication/serializers/__init__.py
@@ -1,4 +1,3 @@
-from .auth import AuthSerializer
-from .change_password import ChangePasswordSerializer
-from .make_user import MakeUserSerializer
-from .reset_password import PasswordResetSerializer
+from app.authentication.serializers.auth import AuthSerializer
+from app.authentication.serializers.change_password import ChangePasswordSerializer
+from app.authentication.serializers.reset_password import PasswordResetSerializer

--- a/app/authentication/serializers/make_user.py
+++ b/app/authentication/serializers/make_user.py
@@ -1,5 +1,0 @@
-from rest_framework import serializers
-
-
-class MakeUserSerializer(serializers.Serializer):
-    user_id = serializers.CharField(max_length=200)

--- a/app/authentication/urls.py
+++ b/app/authentication/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 
-from .views import login, makeMember
+from app.authentication.views import login
 
 router = routers.DefaultRouter()
 
@@ -9,7 +9,6 @@ router = routers.DefaultRouter()
 urlpatterns = [
     url(r"", include(router.urls)),
     url(r"^login", login),
-    url(r"^make", makeMember),
     url(r"^rest-auth/", include("rest_auth.urls")),
     url(r"^", include("django.contrib.auth.urls")),
     # url(r'^token', obtain_auth_token), #Used to bypass all restrictions when getting token

--- a/app/authentication/views.py
+++ b/app/authentication/views.py
@@ -49,29 +49,3 @@ def _try_to_get_user(user_id):
         return User.objects.get(user_id=user_id)
     except User.DoesNotExist:
         raise APIAuthUserDoesNotExist
-
-
-@api_view(["POST"])
-@permission_classes([IsDev, IsHS])
-def makeMember(request):
-    # Serialize data and check if valid
-    serializer = MakeUserSerializer(data=request.data)
-    if not serializer.is_valid():
-        return Response({"detail": "Ugyldig brukernavn"}, status=400)
-
-    # Get username and password
-    user_id = serializer.data["user_id"]
-
-    user = User.objects.get(user_id=user_id)
-    if user is not None:
-        try:
-            Token.objects.get(user_id=user_id)
-            return Response(
-                {"detail": "Brukeren er allerede et TIHLDE medlem"}, status=400
-            )
-        except Token.DoesNotExist as token_not_exist:
-            capture_exception(token_not_exist)
-            Token.objects.create(user=user)
-            return Response({"detail": "Nytt TIHLDE medlem opprettet"}, status=200)
-    else:
-        return Response({"detail": "Ugyldig brukernavn"}, status=400)

--- a/app/authentication/views.py
+++ b/app/authentication/views.py
@@ -1,13 +1,12 @@
 from rest_framework import status
 from rest_framework.authtoken.models import Token
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 from sentry_sdk import capture_exception
 
 from app.authentication.exceptions import APIAuthUserDoesNotExist
-from app.authentication.serializers import AuthSerializer, MakeUserSerializer
-from app.common.permissions import IsDev, IsHS
+from app.authentication.serializers import AuthSerializer
 from app.content.models.user import User
 
 

--- a/app/content/views/makeTIHLDEMember.py
+++ b/app/content/views/makeTIHLDEMember.py
@@ -10,7 +10,7 @@ from app.group.models import Group, Membership
 
 
 @api_view(["POST"])
-@permission_classes((IsHS|IsDev,))
+@permission_classes((IsHS | IsDev,))
 def makeTIHLDEMember(request):
     TIHLDE = Group.objects.get(slug=Groups.TIHLDE)
     user_id = request.data["user_id"]

--- a/app/content/views/makeTIHLDEMember.py
+++ b/app/content/views/makeTIHLDEMember.py
@@ -10,7 +10,7 @@ from app.group.models import Group, Membership
 
 
 @api_view(["POST"])
-@permission_classes([IsDev, IsHS])
+@permission_classes((IsHS|IsDev,))
 def makeTIHLDEMember(request):
     TIHLDE = Group.objects.get(slug=Groups.TIHLDE)
     user_id = request.data["user_id"]

--- a/app/group/serializers/membership.py
+++ b/app/group/serializers/membership.py
@@ -1,13 +1,13 @@
 from rest_framework import serializers
 
 from app.common.serializers import BaseModelSerializer
-from app.content.serializers.user import DefaultUserSerializer, UserSerializer
+from app.content.serializers.user import UserListSerializer, UserSerializer
 from app.group.models import Membership, MembershipHistory
 from app.group.serializers.group import DefaultGroupSerializer, GroupSerializer
 
 
 class MembershipSerializer(BaseModelSerializer):
-    user = DefaultUserSerializer(read_only=True)
+    user = UserListSerializer(read_only=True)
     group = DefaultGroupSerializer(read_only=True)
 
     class Meta:
@@ -55,7 +55,7 @@ class UpdateMembershipSerializer(MembershipSerializer):
 
 
 class MembershipHistorySerializer(serializers.ModelSerializer):
-    user = DefaultUserSerializer(read_only=True)
+    user = UserListSerializer(read_only=True)
     group = DefaultGroupSerializer(read_only=True)
 
     class Meta:

--- a/app/group/serializers/membership.py
+++ b/app/group/serializers/membership.py
@@ -1,7 +1,10 @@
 from rest_framework import serializers
 
 from app.common.serializers import BaseModelSerializer
-from app.content.serializers.user import DefaultUserSerializer, UserListSerializer
+from app.content.serializers.user import (
+    DefaultUserSerializer,
+    UserListSerializer,
+)
 from app.group.models import Membership, MembershipHistory
 from app.group.serializers.group import DefaultGroupSerializer
 

--- a/app/group/serializers/membership.py
+++ b/app/group/serializers/membership.py
@@ -1,13 +1,13 @@
 from rest_framework import serializers
 
 from app.common.serializers import BaseModelSerializer
-from app.content.serializers.user import UserListSerializer, UserSerializer
+from app.content.serializers.user import DefaultUserSerializer, UserListSerializer
 from app.group.models import Membership, MembershipHistory
-from app.group.serializers.group import DefaultGroupSerializer, GroupSerializer
+from app.group.serializers.group import DefaultGroupSerializer
 
 
 class MembershipSerializer(BaseModelSerializer):
-    user = UserListSerializer(read_only=True)
+    user = DefaultUserSerializer(read_only=True)
     group = DefaultGroupSerializer(read_only=True)
 
     class Meta:
@@ -26,8 +26,8 @@ class MembershipSerializer(BaseModelSerializer):
 
 
 class MembershipLeaderSerializer(serializers.ModelSerializer):
-    user = UserSerializer(read_only=True)
-    group = GroupSerializer(read_only=True)
+    user = UserListSerializer(read_only=True)
+    group = DefaultGroupSerializer(read_only=True)
 
     class Meta:
         model = Membership
@@ -55,7 +55,7 @@ class UpdateMembershipSerializer(MembershipSerializer):
 
 
 class MembershipHistorySerializer(serializers.ModelSerializer):
-    user = UserListSerializer(read_only=True)
+    user = DefaultUserSerializer(read_only=True)
     group = DefaultGroupSerializer(read_only=True)
 
     class Meta:


### PR DESCRIPTION
## Proposed changes
The problem was that `@permission_classes([IsDev, IsHS])` checks if the user fullfills both `IsDev` *and* `IsHS`. As Index members also get permission through `IsHS`, we didn't notice this. Switching to `(IsHS|IsDev,)` fixes this as it's an logial OR-check instead of logical AND.

Also removed an excessive `makeMember`-function at the unused `/auth/make`-endpoint.

Also changed user-serializer in membership-serializer to a more performat version.

Issue number: closes #


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures
