### PR TITLE
fix(users): allow admin to update user-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Neste versjon
 - ⚡ **Varsler**. Nye brukere får epost om at bruker er blitt godkjent. Brukere som blir lagt til i en gruppe får varsel.
 - 🦟 **Tilganger**. Fikset bug der HS ikke hadde tilgang til å aktivere nye brukere.
+- ✨ **Brukeradmin**. HS og Index har nå mulighet til å oppdatere brukerdata.
 
 ## Versjon 1.0.8 (01.05.2021)
 - ⚡ **Brukere**. Fjernet felter fra brukere som hentes ut i liste, slik at forespørselen går raskere.

--- a/app/content/serializers/user.py
+++ b/app/content/serializers/user.py
@@ -118,23 +118,19 @@ class UserMemberSerializer(UserSerializer):
             "first_name",
             "last_name",
             "email",
+            "user_class",
+            "user_study",
         )
 
 
 class UserAdminSerializer(serializers.ModelSerializer):
     """Serializer for admin update to prevent them from updating extra_kwargs fields"""
 
-    class Meta:
-        model = User
-        fields = (
-            "user_id",
-            "first_name",
-            "last_name",
-        )
+    class Meta(UserListSerializer.Meta):
+        fields = UserListSerializer.Meta.fields
         read_only_fields = (
             "user_id",
-            "first_name",
-            "last_name",
+            "strikes",
         )
 
 


### PR DESCRIPTION
## Proposed changes
HS and Index didn't have acces to edit users. Updated with giving them access to everything on the user except user_id

Issue number: closes #


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
