### PR TITLE
feat(pages): added serach and pagination to the response when searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Neste versjon
 ## Versjon 1.0.9 (05.05.2021)
+- ⚡ **Om-thilde** Implementert søk på wiki siden
 - ⚡ **Medlemskap**.Lagt til pagination på listing av medlemskap, og filtrering for å hente ut list med bare medlemmer.
 - ⚡ **Varsler**. Nye brukere får epost om at bruker er blitt godkjent. Brukere som blir lagt til i en gruppe får varsel.
 - 🦟 **Tilganger**. Fikset bug der HS ikke hadde tilgang til å aktivere nye brukere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## Neste versjon
 ## Versjon 1.0.9 (05.05.2021)
-- ⚡ **Om-thilde** Implementert søk på wiki siden
+- ⚡ **Pages** Implementert søk i pages siden
 - ⚡ **Medlemskap**.Lagt til pagination på listing av medlemskap, og filtrering for å hente ut list med bare medlemmer.
 - ⚡ **Varsler**. Nye brukere får epost om at bruker er blitt godkjent. Brukere som blir lagt til i en gruppe får varsel.
 - 🦟 **Tilganger**. Fikset bug der HS ikke hadde tilgang til å aktivere nye brukere.

--- a/app/content/serializers/__init__.py
+++ b/app/content/serializers/__init__.py
@@ -13,7 +13,11 @@ from app.content.serializers.notification import (
     NotificationSerializer,
     UpdateNotificationSerializer,
 )
-from app.content.serializers.page import PageSerializer, PageTreeSerializer, PageSearchSerializer
+from app.content.serializers.page import (
+    PageSerializer,
+    PageTreeSerializer,
+    PageSearchSerializer,
+)
 from app.content.serializers.priority import PrioritySerializer
 from app.content.serializers.registration import RegistrationSerializer
 from app.content.serializers.user import (

--- a/app/content/serializers/__init__.py
+++ b/app/content/serializers/__init__.py
@@ -13,7 +13,7 @@ from app.content.serializers.notification import (
     NotificationSerializer,
     UpdateNotificationSerializer,
 )
-from app.content.serializers.page import PageSerializer, PageTreeSerializer
+from app.content.serializers.page import PageSerializer, PageTreeSerializer, PageSearchSerializer
 from app.content.serializers.priority import PrioritySerializer
 from app.content.serializers.registration import RegistrationSerializer
 from app.content.serializers.user import (

--- a/app/content/serializers/__init__.py
+++ b/app/content/serializers/__init__.py
@@ -16,7 +16,7 @@ from app.content.serializers.notification import (
 from app.content.serializers.page import (
     PageSerializer,
     PageTreeSerializer,
-    PageSearchSerializer,
+    PageListSerializer,
 )
 from app.content.serializers.priority import PrioritySerializer
 from app.content.serializers.registration import RegistrationSerializer

--- a/app/content/serializers/page.py
+++ b/app/content/serializers/page.py
@@ -29,6 +29,20 @@ class PageSerializer(BaseModelSerializer):
     def get_path(self, obj):
         return obj.get_path()
 
+class PageSearchSerializer(BaseModelSerializer):
+    path = SerializerMethodField()
+
+    class Meta:
+        model = Page
+        fields = (
+            "slug",
+            "title",
+            "path",  
+        )
+
+    def get_path(self, obj):
+        return obj.get_path()
+
 
 class PageTreeSerializer(serializers.ModelSerializer):
     children = SerializerMethodField()

--- a/app/content/serializers/page.py
+++ b/app/content/serializers/page.py
@@ -29,6 +29,7 @@ class PageSerializer(BaseModelSerializer):
     def get_path(self, obj):
         return obj.get_path()
 
+
 class PageSearchSerializer(BaseModelSerializer):
     path = SerializerMethodField()
 
@@ -37,7 +38,7 @@ class PageSearchSerializer(BaseModelSerializer):
         fields = (
             "slug",
             "title",
-            "path",  
+            "path",
         )
 
     def get_path(self, obj):

--- a/app/content/serializers/page.py
+++ b/app/content/serializers/page.py
@@ -24,13 +24,13 @@ class PageSerializer(BaseModelSerializer):
         )
 
     def get_children(self, obj):
-        return [{"title": page.title, "slug": page.slug} for page in obj.get_children()]
+        return [PageListSerializer(page).data for page in obj.get_children()]
 
     def get_path(self, obj):
         return obj.get_path()
 
 
-class PageSearchSerializer(BaseModelSerializer):
+class PageListSerializer(BaseModelSerializer):
     path = SerializerMethodField()
 
     class Meta:

--- a/app/content/views/page.py
+++ b/app/content/views/page.py
@@ -9,7 +9,7 @@ from app.common.pagination import BasePagination
 from app.common.permissions import BasicViewPermission
 from app.content.models import Page
 from app.content.serializers import (
-    PageSearchSerializer,
+    PageListSerializer,
     PageSerializer,
     PageTreeSerializer,
 )
@@ -38,7 +38,7 @@ class PageViewSet(viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         if self.is_serach():
-            self.serializer_class = PageSearchSerializer
+            self.serializer_class = PageListSerializer
         return super().get_serializer_class()
 
     def retrieve(self, request, *args, **kwargs):

--- a/app/content/views/page.py
+++ b/app/content/views/page.py
@@ -25,7 +25,7 @@ class PageViewSet(viewsets.ModelViewSet):
     lookup_url_kwarg = "path"
     lookup_value_regex = ".*"
 
-    def is_serach(self):
+    def is_search(self):
         return self.request.query_params.get("search")
 
     def get_page_from_tree(self):
@@ -37,7 +37,7 @@ class PageViewSet(viewsets.ModelViewSet):
         return super(PageViewSet, self).get_permissions()
 
     def get_serializer_class(self):
-        if self.is_serach():
+        if self.is_search():
             self.serializer_class = PageListSerializer
         return super().get_serializer_class()
 
@@ -63,7 +63,7 @@ class PageViewSet(viewsets.ModelViewSet):
 
     def list(self, request, *args, **kwargs):
         try:
-            if self.is_serach():
+            if self.is_search():
                 return super().list(request, *args, **kwargs)
             page = self.queryset.get(parent=None)
             serializer = PageSerializer(page, many=False)

--- a/app/content/views/page.py
+++ b/app/content/views/page.py
@@ -8,7 +8,11 @@ from sentry_sdk import capture_exception
 from app.common.pagination import BasePagination
 from app.common.permissions import BasicViewPermission
 from app.content.models import Page
-from app.content.serializers import PageSerializer, PageTreeSerializer, PageSearchSerializer
+from app.content.serializers import (
+    PageSearchSerializer,
+    PageSerializer,
+    PageTreeSerializer,
+)
 
 
 class PageViewSet(viewsets.ModelViewSet):
@@ -36,7 +40,6 @@ class PageViewSet(viewsets.ModelViewSet):
         if self.is_serach():
             self.serializer_class = PageSearchSerializer
         return super().get_serializer_class()
-    
 
     def retrieve(self, request, *args, **kwargs):
         try:


### PR DESCRIPTION
## Proposed changes
Added serach and pagination to the response when searching, this search only allows you to search on all pages, and cannot restrict the search to a spesific folder. its used by adding the query param serach page/?search=lover

Issue number: closes #39 
![Screenshot from 2021-05-08 11-59-52](https://user-images.githubusercontent.com/60223374/117535217-0a531f00-aff5-11eb-8891-e122c8df1bf1.png)





## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures

