### PR TITLE
fix(celery): fix revoke and prevent duplicate runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 
 ## Neste versjon
+- 🦟 **Celery**. Fikset Celery tasks slik at man ikke kjører samme flere ganger lengre.
 ## Versjon 1.0.10 (10.05.2021)
 - ⚡ **Bruker** Lagt til egne endpunkter for å hente ut relatert bruker data
 ## Versjon 1.0.9 (05.05.2021)

--- a/app/content/signals.py
+++ b/app/content/signals.py
@@ -10,41 +10,29 @@ from app.content.tasks.event import (
     event_end_schedular,
     event_sign_off_deadline_schedular,
 )
-from app.util.utils import datetime_format, disable_for_loaddata, midday
+from app.util.utils import disable_for_loaddata, midday
 
 logger = logging.getLogger(__name__)
 
 
 @disable_for_loaddata
 def send_event_reminders(sender, instance, created, **kwargs):
-    # if settings.ENVIRONMENT == EnvironmentOptions.PRODUCTION:
-    run_celery_tasks_for_event(instance)
+    if settings.ENVIRONMENT == EnvironmentOptions.PRODUCTION:
+        run_celery_tasks_for_event(instance)
 
 
 def run_celery_tasks_for_event(event):
     try:
-        print("run celery tasks")
         app.control.revoke(event.end_date_schedular_id, terminate=True)
         app.control.revoke(event.sign_off_deadline_schedular_id, terminate=True)
         if should_send_incoming_end_date_reminder(event):
             event.end_date_schedular_id = event_end_schedular.apply_async(
                 eta=(midday(event.end_date + timedelta(days=1))),
-                kwargs={
-                    "pk": event.pk,
-                    "title": event.title,
-                    "start_date": datetime_format(event.start_date),
-                    "evaluate_link": event.evaluate_link,
-                },
             )
         if should_send_incoming_sign_off_deadline_reminder(event):
-            print("run should_send_incoming_sign_off_deadline_reminder")
-            print(datetime.now())
-            print(datetime.now() + timedelta(seconds=15) - timedelta(hours=2))
             event.sign_off_deadline_schedular_id = event_sign_off_deadline_schedular.apply_async(
-                eta=(datetime.now() + timedelta(seconds=15) - timedelta(hours=2)),
-                kwargs={"pk": event.pk, "title": event.title},
+                eta=(midday(event.sign_off_deadline - timedelta(days=1))),
             )
-            print(event.sign_off_deadline_schedular_id)
         event.save()
     except Exception as e:
         logging.info(e)

--- a/app/content/signals.py
+++ b/app/content/signals.py
@@ -1,10 +1,9 @@
 import logging
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 from django.conf import settings
 
 from app.celery import app
-
 from app.common.enums import EnvironmentOptions
 from app.content.tasks.event import (
     event_end_schedular,

--- a/app/content/tasks/event.py
+++ b/app/content/tasks/event.py
@@ -13,24 +13,30 @@ from app.util.utils import datetime_format
 @shared_task
 def event_sign_off_deadline_schedular():
     from app.content.models import Event
+
     try:
-      event = Event.objects.get(sign_off_deadline_schedular_id=event_sign_off_deadline_schedular.request.id)
-      for registration in Registration.objects.filter(event__pk=event.id, is_on_wait=False):
-          send_html_email(
-              "Påminnelse om avmeldingsfrist for " + event.title,
-              render_to_string(
-                  "sign_off_deadline.html",
-                  context={
-                      "user_name": registration.user.first_name,
-                      "event_name": event.title,
-                      "event_id": event.id,
-                  },
-              ),
-              registration.user.email,
-          )
-          Notification.objects.create(
-              user=registration.user, message="Påminnelse om avmeldingsfrist for " + event.title
-          )
+        event = Event.objects.get(
+            sign_off_deadline_schedular_id=event_sign_off_deadline_schedular.request.id
+        )
+        for registration in Registration.objects.filter(
+            event__pk=event.id, is_on_wait=False
+        ):
+            send_html_email(
+                "Påminnelse om avmeldingsfrist for " + event.title,
+                render_to_string(
+                    "sign_off_deadline.html",
+                    context={
+                        "user_name": registration.user.first_name,
+                        "event_name": event.title,
+                        "event_id": event.id,
+                    },
+                ),
+                registration.user.email,
+            )
+            Notification.objects.create(
+                user=registration.user,
+                message="Påminnelse om avmeldingsfrist for " + event.title,
+            )
     except Event.DoesNotExist as event_not_exist:
         capture_exception(event_not_exist)
 
@@ -38,11 +44,16 @@ def event_sign_off_deadline_schedular():
 @shared_task
 def event_end_schedular():
     from app.content.models import Event
+
     try:
         event = Event.objects.get(end_date_schedular_id=event_end_schedular.request.id)
-        for registration in Registration.objects.filter(event__pk=event.id, has_attended=False):
+        for registration in Registration.objects.filter(
+            event__pk=event.id, has_attended=False
+        ):
             create_strike("NO_SHOW", registration.user, registration.event)
-        for registration in Registration.objects.filter(event__pk=event.id, has_attended=True):
+        for registration in Registration.objects.filter(
+            event__pk=event.id, has_attended=True
+        ):
             send_html_email(
                 "Evaluering av " + event.title,
                 render_to_string(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,12 +47,5 @@ services:
     image: celery
     container_name: celery
     entrypoint: []
-    command: celery -A app worker -E -l info --without-heartbeat --without-gossip --without-mingle
+    command: celery -A app worker -l info --without-heartbeat --without-gossip --without-mingle
     ports: []
-
-  flower:
-    image: mher/flower:0.9.5
-    container_name: flower
-    command: ['flower', '--broker=amqps://vecuosxj:eVqg9CTtGrCaSLATFmbiuHDGyjTrBsz4@hawk.rmq.cloudamqp.com/vecuosxj', '--port=5555', '--url-prefix=flower']
-    ports:
-      - "5555:5555"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,5 +47,12 @@ services:
     image: celery
     container_name: celery
     entrypoint: []
-    command: celery -A app worker -l info --without-heartbeat --without-gossip --without-mingle
+    command: celery -A app worker -E -l info --without-heartbeat --without-gossip --without-mingle
     ports: []
+
+  flower:
+    image: mher/flower:0.9.5
+    container_name: flower
+    command: ['flower', '--broker=amqps://vecuosxj:eVqg9CTtGrCaSLATFmbiuHDGyjTrBsz4@hawk.rmq.cloudamqp.com/vecuosxj', '--port=5555', '--url-prefix=flower']
+    ports:
+      - "5555:5555"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp-cors
 wheel
 mysqlclient == 2.0.3
 sentry-sdk
-celery ~= 4.4
+celery == 5.0.5
 azure-storage-blob == 12.8.0
 python-dotenv ~= 0.17
 


### PR DESCRIPTION
Quite sure that it works, but not 100% sure

## Proposed changes
- Upgraded Celery to new major version 5.0.5
- Fixed revoke issue (I think)
- Changed how the event is retrieved by using the celery "request.id" instead
  - This means that only 1 event can have that id, and therefore other tasks will not find the event and therefore not run
  - This also allows us to not add kwargs to the task
- This should be manually tested, steps:
  1. Add flower-image as new container
     - This allows you to see all tasks and info about them
  2. Adjust eta in apply_async to run soon after save so you don't have to wait
  3. Turn of setting which makes this only run in production

Issue number: closes #31 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
