### PR TITLE
fix(celery): stop stack overflow on event save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 
 ## Neste versjon
+- 🦟 **Celery**. Fikset problem der oppdatering av arrangement førte til evig rekursjon.
 ## Versjon 1.0.11 (11.08.2021)
 - ✨ **Brukere**. Admins kan nå slette nye "ventende" brukere og legge ved en begrunnelse.
 - 🦟 **Celery**. Fikset Celery tasks slik at man ikke kjører samme flere ganger lengre.

--- a/app/content/signals.py
+++ b/app/content/signals.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 
 from django.conf import settings
 
+from sentry_sdk import capture_exception
+
 from app.celery import app
 from app.common.enums import EnvironmentOptions
 from app.content.tasks.event import (
@@ -19,14 +21,13 @@ def send_event_reminders(sender, instance, created, **kwargs):
     if settings.ENVIRONMENT == EnvironmentOptions.PRODUCTION:
         run_celery_tasks_for_event(instance)
 
-
 def run_celery_tasks_for_event(event):
     try:
         end_date_reminder(event)
         sign_off_deadline_reminder(event)
-        event.save()
     except Exception as e:
         logging.info(e)
+        capture_exception(e)
 
 
 def end_date_reminder(event):
@@ -38,8 +39,16 @@ def end_date_reminder(event):
         and not event.closed
         and isFuture(eta)
     ):
-        app.control.revoke(event.end_date_schedular_id, terminate=True)
-        event.end_date_schedular_id = event_end_schedular.apply_async(eta=(eta),)
+        try:
+            app.control.revoke(event.end_date_schedular_id, terminate=True)
+            new_task_id = event_end_schedular.apply_async(
+                kwargs={'eventId': event.id, 'eta': eta, 'type': 'end_date_reminder'},
+                eta=(eta),
+            )
+            from app.content.models import Event
+            Event.objects.filter(id=event.id).update(end_date_schedular_id=new_task_id)
+        except Exception as e:
+            capture_exception(e)
 
 
 def sign_off_deadline_reminder(event):
@@ -51,10 +60,16 @@ def sign_off_deadline_reminder(event):
         and not event.closed
         and isFuture(eta)
     ):
-        app.control.revoke(event.sign_off_deadline_schedular_id, terminate=True)
-        event.sign_off_deadline_schedular_id = event_sign_off_deadline_schedular.apply_async(
-            eta=(eta),
-        )
+        try:
+            app.control.revoke(event.sign_off_deadline_schedular_id, terminate=True)
+            new_task_id = event_sign_off_deadline_schedular.apply_async(
+                kwargs={'eventId': event.id, 'eta': eta, 'type': 'sign_off_deadline_reminder'},
+                eta=(eta),
+            )
+            from app.content.models import Event
+            Event.objects.filter(id=event.id).update(sign_off_deadline_schedular_id=new_task_id)
+        except Exception as e:
+            capture_exception(e)
 
 
 def isFuture(eta):

--- a/app/content/signals.py
+++ b/app/content/signals.py
@@ -21,6 +21,7 @@ def send_event_reminders(sender, instance, created, **kwargs):
     if settings.ENVIRONMENT == EnvironmentOptions.PRODUCTION:
         run_celery_tasks_for_event(instance)
 
+
 def run_celery_tasks_for_event(event):
     try:
         end_date_reminder(event)
@@ -42,10 +43,11 @@ def end_date_reminder(event):
         try:
             app.control.revoke(event.end_date_schedular_id, terminate=True)
             new_task_id = event_end_schedular.apply_async(
-                kwargs={'eventId': event.id, 'eta': eta, 'type': 'end_date_reminder'},
+                kwargs={"eventId": event.id, "eta": eta, "type": "end_date_reminder"},
                 eta=(eta),
             )
             from app.content.models import Event
+
             Event.objects.filter(id=event.id).update(end_date_schedular_id=new_task_id)
         except Exception as e:
             capture_exception(e)
@@ -63,11 +65,18 @@ def sign_off_deadline_reminder(event):
         try:
             app.control.revoke(event.sign_off_deadline_schedular_id, terminate=True)
             new_task_id = event_sign_off_deadline_schedular.apply_async(
-                kwargs={'eventId': event.id, 'eta': eta, 'type': 'sign_off_deadline_reminder'},
+                kwargs={
+                    "eventId": event.id,
+                    "eta": eta,
+                    "type": "sign_off_deadline_reminder",
+                },
                 eta=(eta),
             )
             from app.content.models import Event
-            Event.objects.filter(id=event.id).update(sign_off_deadline_schedular_id=new_task_id)
+
+            Event.objects.filter(id=event.id).update(
+                sign_off_deadline_schedular_id=new_task_id
+            )
         except Exception as e:
             capture_exception(e)
 

--- a/app/content/tasks/event.py
+++ b/app/content/tasks/event.py
@@ -11,7 +11,7 @@ from app.util.utils import datetime_format
 
 
 @shared_task
-def event_sign_off_deadline_schedular():
+def event_sign_off_deadline_schedular(*args, **kwargs):
     from app.content.models import Event
 
     try:
@@ -42,7 +42,7 @@ def event_sign_off_deadline_schedular():
 
 
 @shared_task
-def event_end_schedular():
+def event_end_schedular(*args, **kwargs):
     from app.content.models import Event
 
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp-cors
 wheel
 mysqlclient == 2.0.3
 sentry-sdk
-celery == 5.0.5
+celery == 5.1.2
 azure-storage-blob == 12.8.0
 python-dotenv ~= 0.17
 


### PR DESCRIPTION
## Proposed changes
- Oppdatert `celery` versjon til 5.1.2 uten at det inkluderer noen store endringer.
- Endret også oppdatering av events i `signals.py` til å bruke `queryset.update()` istedenfor `event.save()` siden save() fører til ny kjøring av signalet og dermed legger opp til en evig rekursjon som er problemet i #160 .
- La til `*args, **kwargs` som parametre i celery-tasks'ene for å fjerne errors som har oppstått.

Issue number: closes #160 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
