### PR TITLE
feat(membership): added functionality for swapping hs members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## Neste versjon
 - ✨ **Svar på spørreskjemaer** Medlemmer kan nå svare på spørreskjemaer.
+- ✨ **Grupper** Ledere for undergrupper blir nå automagisk medlem av hs gruppen 
+
 ## Versjon 1.0.12 (22.08.2021)
 - 🦟 **Celery**. Fikset problem der oppdatering av arrangement førte til evig rekursjon.
 - ✨ **Varsler**. Varsler kan nå inneholder linker til relevant innhold.

--- a/app/group/models/membership.py
+++ b/app/group/models/membership.py
@@ -87,7 +87,10 @@ class Membership(BaseModel, BasePermissionModel):
         return self.membership_type in MembershipType.board_members
 
     def clean(self):
-        if self.membership_type == MembershipType.MEMBER and self.group.type == GroupType.SUBGROUP:
+        if (
+            self.membership_type == MembershipType.MEMBER
+            and self.group.type == GroupType.SUBGROUP
+        ):
             self.delete_hs_membership()
 
         if self.membership_type in MembershipType.board_members():
@@ -103,18 +106,17 @@ class Membership(BaseModel, BasePermissionModel):
 
     def delete_hs_membership(self):
         seat_to_delete = (
-                Membership.objects.select_for_update()
-                .filter(group__slug=AdminGroup.HS, user=self.user)
-                .first()
-            )
+            Membership.objects.select_for_update()
+            .filter(group__slug=AdminGroup.HS, user=self.user)
+            .first()
+        )
         if seat_to_delete:
             seat_to_delete.delete()
-            
+
     @atomic
     def swap_hs_seat(self, previous_seat):
         seat_to_delete = None
         if previous_seat:
-            print("skjnkjdsdkjsndskjndsk")
             seat_to_delete = (
                 Membership.objects.select_for_update()
                 .filter(group__slug=AdminGroup.HS, user=previous_seat.user)
@@ -124,7 +126,6 @@ class Membership(BaseModel, BasePermissionModel):
         if seat_to_delete:
             MembershipHistory.from_membership(membership=seat_to_delete)
             seat_to_delete.delete()
-
         group = Group.objects.filter(slug=AdminGroup.HS).first()
 
         if group and self:
@@ -135,7 +136,6 @@ class Membership(BaseModel, BasePermissionModel):
 
     @atomic
     def swap_board(self):
-        print("skjnkjdsdkjsndskjndsk")
         previous_board_member = (
             Membership.objects.select_for_update()
             .filter(group=self.group, membership_type=self.membership_type)

--- a/app/group/tests/test_membership_model.py
+++ b/app/group/tests/test_membership_model.py
@@ -1,9 +1,9 @@
 import pytest
 
-from app.common.enums import MembershipType
+from app.common.enums import AdminGroup, GroupType, MembershipType
 from app.group.factories import MembershipFactory
 from app.group.factories.group_factory import GroupFactory
-from app.group.models.membership import MembershipHistory
+from app.group.models.membership import Membership, MembershipHistory
 
 
 @pytest.fixture()
@@ -19,6 +19,10 @@ def membership_leader():
 @pytest.fixture()
 def group():
     return GroupFactory()
+
+@pytest.fixture()
+def hs():
+    return GroupFactory(name=AdminGroup.HS, slug=AdminGroup.HS)
 
 
 @pytest.mark.django_db
@@ -82,3 +86,40 @@ def test_swap_leader_does_not_create_two_leaders(group):
 def test_on_delete_membership_history_is_created(membership):
     membership.delete()
     assert MembershipHistory.objects.get(start_date=membership.created_at)
+
+
+@pytest.mark.django_db
+def test_on_swap_creates_hs_membership_with_no_leader(hs):
+    """"
+        Tests that if you promote as user to leader of a subgroup with no leader,
+        the user is automaticly added to the HS group
+    """
+    group = GroupFactory(type=GroupType.SUBGROUP)
+    membership = MembershipFactory(membership_type=MembershipType.MEMBER, group=group)
+    membership.membership_type = MembershipType.LEADER
+    membership.save()
+    membership.refresh_from_db()
+    assert membership.membership_type == MembershipType.LEADER  
+    assert Membership.objects.get(user = membership.user, group=hs)
+
+@pytest.mark.django_db
+def test_on_swap_creates_hs_membership_with_leader(hs):
+    """
+    Tests that if you promote as user to leader of a subgroup, 
+    the user is automaticly added to the HS group
+    """
+    group = GroupFactory(type=GroupType.SUBGROUP)
+    membership = MembershipFactory(membership_type=MembershipType.MEMBER, group=group)
+    membership_leader = MembershipFactory(
+        membership_type=MembershipType.LEADER, group=group
+    )
+    membership.membership_type = MembershipType.LEADER
+    membership.save()
+    membership.refresh_from_db()
+    membership_leader.refresh_from_db()
+    assert membership.membership_type == MembershipType.LEADER  
+    assert membership_leader.membership_type == MembershipType.MEMBER  
+    assert Membership.objects.get(user = membership.user, group=hs)
+
+    
+

--- a/app/group/tests/test_membership_model.py
+++ b/app/group/tests/test_membership_model.py
@@ -20,6 +20,7 @@ def membership_leader():
 def group():
     return GroupFactory()
 
+
 @pytest.fixture()
 def hs():
     return GroupFactory(name=AdminGroup.HS, slug=AdminGroup.HS)
@@ -99,13 +100,14 @@ def test_on_swap_creates_hs_membership_with_no_leader(hs):
     membership.membership_type = MembershipType.LEADER
     membership.save()
     membership.refresh_from_db()
-    assert membership.membership_type == MembershipType.LEADER  
-    assert Membership.objects.get(user = membership.user, group=hs)
+    assert membership.membership_type == MembershipType.LEADER
+    assert Membership.objects.get(user=membership.user, group=hs)
+
 
 @pytest.mark.django_db
 def test_on_swap_creates_hs_membership_with_leader(hs):
     """
-    Tests that if you promote as user to leader of a subgroup, 
+    Tests that if you promote as user to leader of a subgroup,
     the user is automaticly added to the HS group
     """
     group = GroupFactory(type=GroupType.SUBGROUP)
@@ -117,14 +119,15 @@ def test_on_swap_creates_hs_membership_with_leader(hs):
     membership.save()
     membership.refresh_from_db()
     membership_leader.refresh_from_db()
-    assert membership.membership_type == MembershipType.LEADER  
-    assert membership_leader.membership_type == MembershipType.MEMBER  
-    assert Membership.objects.get(user = membership.user, group=hs)
+    assert membership.membership_type == MembershipType.LEADER
+    assert membership_leader.membership_type == MembershipType.MEMBER
+    assert Membership.objects.get(user=membership.user, group=hs)
+
 
 @pytest.mark.django_db
 def test_on_remove_leader_without_swap_removes_hs(hs):
     """
-    Tests that if you demote as user from leader to member of a subgroup, 
+    Tests that if you demote as user from leader to member of a subgroup,
     the user is automaticly removed from the HS group
     """
     group = GroupFactory(type=GroupType.SUBGROUP)
@@ -132,8 +135,5 @@ def test_on_remove_leader_without_swap_removes_hs(hs):
     membership.membership_type = MembershipType.MEMBER
     membership.save()
     membership.refresh_from_db()
-    assert membership.membership_type == MembershipType.MEMBER  
-    assert  not len(Membership.objects.filter(user = membership.user, group=hs))
-
-    
-
+    assert membership.membership_type == MembershipType.MEMBER
+    assert not len(Membership.objects.filter(user=membership.user, group=hs))

--- a/app/group/tests/test_membership_model.py
+++ b/app/group/tests/test_membership_model.py
@@ -121,5 +121,19 @@ def test_on_swap_creates_hs_membership_with_leader(hs):
     assert membership_leader.membership_type == MembershipType.MEMBER  
     assert Membership.objects.get(user = membership.user, group=hs)
 
+@pytest.mark.django_db
+def test_on_remove_leader_without_swap_removes_hs(hs):
+    """
+    Tests that if you demote as user from leader to member of a subgroup, 
+    the user is automaticly removed from the HS group
+    """
+    group = GroupFactory(type=GroupType.SUBGROUP)
+    membership = MembershipFactory(membership_type=MembershipType.LEADER, group=group)
+    membership.membership_type = MembershipType.MEMBER
+    membership.save()
+    membership.refresh_from_db()
+    assert membership.membership_type == MembershipType.MEMBER  
+    assert  not len(Membership.objects.filter(user = membership.user, group=hs))
+
     
 


### PR DESCRIPTION
## Proposed changes
Added logic for promoting and swaping hs members when a leader of a subgroup is changed.

Issue number: closes #105 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [ ] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
