### PR TITLE
fix(forms): statistics and submissions

### DIFF
--- a/app/content/views/user_badge.py
+++ b/app/content/views/user_badge.py
@@ -13,6 +13,7 @@ class UserBadgeViewSet(viewsets.ModelViewSet):
     serializer_class = UserBadgeSerializer
     permission_classes = [BasicViewPermission]
     queryset = UserBadge.objects.all()
+    http_method_names = ['post']
 
     def create(self, request):
         try:

--- a/app/forms/serializers/statistics.py
+++ b/app/forms/serializers/statistics.py
@@ -24,7 +24,7 @@ class OptionStatisticsSerializer(BaseModelSerializer):
     def get_answer_percentage(self, obj):
         amount = self.get_answer_amount(obj)
         total = obj.field.form.submissions.count()
-        return round(amount / total * 100, 2)
+        return round(amount / total * 100 if total > 0 else 0, 2)
 
 
 class FieldStatisticsSerializer(BaseModelSerializer):

--- a/app/forms/views/form.py
+++ b/app/forms/views/form.py
@@ -26,5 +26,5 @@ class FormViewSet(viewsets.ModelViewSet):
     def destroy(self, request, *args, **kwargs):
         super().destroy(request, *args, **kwargs)
         return Response(
-            {"detail": "Skjemaet ble slettet"}, status=status.HTTP_204_NO_CONTENT
+            {"detail": "Skjemaet ble slettet"}, status=status.HTTP_200_OK
         )

--- a/app/forms/views/submission.py
+++ b/app/forms/views/submission.py
@@ -22,6 +22,11 @@ class SubmissionViewSet(viewsets.ModelViewSet):
         )
         return context
 
+    def get_queryset(self):
+        if hasattr(self, "action") and self.action == "list":
+            return self.queryset.filter(form__id=self.kwargs.get("form_id"))
+        return self.queryset
+
     def create(self, request, *args, **kwargs):
         form = get_object_or_404(Form.objects.all(), id=kwargs.get("form_id"))
         if isinstance(form, EventForm):

--- a/app/tests/forms/test_form_integration.py
+++ b/app/tests/forms/test_form_integration.py
@@ -485,9 +485,9 @@ def test_delete_form_as_member_is_not_permitted(member, form):
     [
         (AdminGroup.SOSIALEN, status.HTTP_403_FORBIDDEN),
         (AdminGroup.PROMO, status.HTTP_403_FORBIDDEN),
-        (AdminGroup.HS, status.HTTP_204_NO_CONTENT),
-        (AdminGroup.INDEX, status.HTTP_204_NO_CONTENT),
-        (AdminGroup.NOK, status.HTTP_204_NO_CONTENT),
+        (AdminGroup.HS, status.HTTP_200_OK),
+        (AdminGroup.INDEX, status.HTTP_200_OK),
+        (AdminGroup.NOK, status.HTTP_200_OK),
     ],
 )
 def test_delete_form_as_member_of_admin_group(


### PR DESCRIPTION
Fixes bug which lead to a divide by zero error, a wrong response code on destroy and an error where all submissions was returned on `/submission/`, with no filtering of form