### PR TITLE
fix(timezone): fix timezone formatting for emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 
 ## Neste versjon
+- 🦟 **Tidssoner**. Fikset bug der tidspunkter i eposter blir formatert med feil tidssone.
 ## Versjon 1.0.14 (12.09.2021)
 - ✨ **Svar på spørreskjemaer** blir nå sendt med sammen med påmeldingen.
 - ✨ **Statistikk spørreskjemaer** Kan nå hente ut statistikk over svar på spørreskjemaer.

--- a/app/util/utils.py
+++ b/app/util/utils.py
@@ -2,8 +2,6 @@ import logging
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 
-from django.utils.formats import date_format, time_format
-
 from pytz import timezone as pytz_timezone
 
 logger = logging.getLogger(__name__)
@@ -18,7 +16,12 @@ def today():
 
 
 def datetime_format(date_time):
-    return f"{date_format(date_time)} {time_format(date_time)}"
+    from django.template import Context, Template
+
+    # Using Django Template to format as it formats dates with both localization and timezone automatically
+    return Template("{{ date_to_format }}").render(
+        Context(dict(date_to_format=date_time))
+    )
 
 
 def midday(date_time):


### PR DESCRIPTION
## Proposed changes
Switch to using Djangos Built-in Template to format datetime which also automatically formats dates with both localization and timezone

Issue number: closes #175 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
