### PR TITLE
feat(registration): deny registrations for users with unanswered evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@
 ---
 
 ## Neste versjon
+- ✨ **Evalueringer** må bli besvart før neste påmelding.
+
 ## Versjon 1.0.15 (15.09.2021)
 - 🦟 **Tidssoner**. Fikset bug der tidspunkter i eposter blir formatert med feil tidssone.
+
 ## Versjon 1.0.14 (12.09.2021)
 - ✨ **Svar på spørreskjemaer** blir nå sendt med sammen med påmeldingen.
 - ✨ **Statistikk spørreskjemaer** Kan nå hente ut statistikk over svar på spørreskjemaer.
-- ✨ **Evalueringer** må bli besvart før neste påmelding.
 
 ## Versjon 1.0.13 (06.09.2021)
 - ✨ **Svar på spørreskjemaer** Medlemmer kan nå svare på spørreskjemaer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ## Versjon 1.0.14 (12.09.2021)
 - ✨ **Svar på spørreskjemaer** blir nå sendt med sammen med påmeldingen.
 - ✨ **Statistikk spørreskjemaer** Kan nå hente ut statistikk over svar på spørreskjemaer.
+- ✨ **Evalueringer** må bli besvart før neste påmelding.
 
 ## Versjon 1.0.13 (06.09.2021)
 - ✨ **Svar på spørreskjemaer** Medlemmer kan nå svare på spørreskjemaer.

--- a/app/content/exceptions.py
+++ b/app/content/exceptions.py
@@ -12,9 +12,20 @@ class APIEventSignOffDeadlineHasPassed(APIException):
     default_detail = "Du kan ikke melde deg av etter avmeldingsfristen"
 
 
+class APIUnansweredFormException(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = (
+        "Du har ubesvarte evalueringsskjemaer som må besvares før du kan melde deg på"
+    )
+
+
 class EventSignOffDeadlineHasPassed(ValueError):
     pass
 
 
 class StrikeError(ValueError):
+    pass
+
+
+class UnansweredFormError(ValueError):
     pass

--- a/app/content/factories/__init__.py
+++ b/app/content/factories/__init__.py
@@ -1,4 +1,7 @@
-from app.content.factories.event_factory import EventFactory, EventWithSignalsFactory
+from app.content.factories.event_factory import (
+    EventFactory,
+    EventWithSignalsFactory,
+)
 from app.content.factories.priority_factory import PriorityFactory
 from app.content.factories.user_factory import UserFactory
 from app.content.factories.registration_factory import RegistrationFactory

--- a/app/content/factories/event_factory.py
+++ b/app/content/factories/event_factory.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 import factory
 from factory.django import DjangoModelFactory
 
-from ..models import Event
+from app.content.models.event import Event
 
 
 class EventWithSignalsFactory(DjangoModelFactory):

--- a/app/content/mixins.py
+++ b/app/content/mixins.py
@@ -1,6 +1,8 @@
 from app.content.exceptions import (
     APIEventSignOffDeadlineHasPassed,
+    APIUnansweredFormException,
     EventSignOffDeadlineHasPassed,
+    UnansweredFormError,
 )
 from app.util.mixins import APIErrorsMixin
 
@@ -11,4 +13,5 @@ class APIRegistrationErrorsMixin(APIErrorsMixin):
         return {
             **super().expected_exceptions,
             EventSignOffDeadlineHasPassed: APIEventSignOffDeadlineHasPassed,
+            UnansweredFormError: APIUnansweredFormException,
         }

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -112,6 +112,17 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
 
     objects = UserManager()
 
+    def has_unanswered_evaluations(self):
+        return self.get_unanswered_evaluations().exists()
+
+    def get_unanswered_evaluations(self):
+        from app.forms.models.forms import EventForm, EventFormType
+
+        registrations = self.registrations.filter(has_attended=True)
+        return EventForm.objects.filter(
+            event__registrations__in=registrations, type=EventFormType.EVALUATION
+        ).exclude(submissions__user=self)
+
     @classmethod
     def has_retrieve_permission(cls, request):
         if request.user:

--- a/app/content/serializers/event.py
+++ b/app/content/serializers/event.py
@@ -13,6 +13,7 @@ class EventSerializer(serializers.ModelSerializer):
     registration_priorities = serializers.SerializerMethodField()
     evaluation = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
     survey = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
+    viewer_has_unanswered_evaluations = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
@@ -41,6 +42,7 @@ class EventSerializer(serializers.ModelSerializer):
             "evaluation",
             "survey",
             "updated_at",
+            "viewer_has_unanswered_evaluations",
         )
 
         extra_kwargs = {
@@ -82,6 +84,11 @@ class EventSerializer(serializers.ModelSerializer):
             ]
         except Priority.DoesNotExist:
             return None
+
+    def get_viewer_has_unanswered_evaluations(self, obj):
+        request = self.context.get("request", None)
+        if request and request.user:
+            return not request.user.has_unanswered_evaluations()
 
 
 class EventListSerializer(serializers.ModelSerializer):

--- a/app/content/serializers/event.py
+++ b/app/content/serializers/event.py
@@ -88,7 +88,7 @@ class EventSerializer(serializers.ModelSerializer):
     def get_viewer_has_unanswered_evaluations(self, obj):
         request = self.context.get("request", None)
         if request and request.user:
-            return not request.user.has_unanswered_evaluations()
+            return request.user.has_unanswered_evaluations()
 
 
 class EventListSerializer(serializers.ModelSerializer):

--- a/app/content/tests/test_user_model.py
+++ b/app/content/tests/test_user_model.py
@@ -1,0 +1,66 @@
+import pytest
+
+from app.content.factories import RegistrationFactory, UserFactory
+from app.forms.enums import EventFormType
+from app.forms.tests.form_factories import EventFormFactory, SubmissionFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def user():
+    return UserFactory()
+
+
+def test_get_unanswered_evaluations_when_has_no_unanswered_evaluations_returns_no_evaluations(
+    user,
+):
+    """
+    Test that no unanswered evaluations are returned
+    when the user has attended an event and answered the evaluation.
+    """
+    evaluation = EventFormFactory(type=EventFormType.EVALUATION)
+    RegistrationFactory(event=evaluation.event, user=user, has_attended=True)
+    SubmissionFactory(form=evaluation, user=user)
+
+    unanswered_evaluations = user.get_unanswered_evaluations()
+
+    assert not unanswered_evaluations.exists()
+
+
+def test_get_unanswered_evaluations_when_has_unanswered_evaluations_returns_unanswered_evaluations(
+    user,
+):
+    """
+    Test that all unanswered evaluations are returned
+    when the user has attended an event and not answered the evaluation.
+    """
+    evaluation = EventFormFactory(type=EventFormType.EVALUATION)
+    RegistrationFactory(event=evaluation.event, user=user, has_attended=True)
+
+    unanswered_evaluations = user.get_unanswered_evaluations()
+
+    assert unanswered_evaluations.count() == 1
+
+
+def test_has_unanswered_evaluations_when_has_no_unanswered_evaluations_returns_true(
+    user,
+):
+    evaluation = EventFormFactory(type=EventFormType.EVALUATION)
+    RegistrationFactory(event=evaluation.event, user=user, has_attended=True)
+    SubmissionFactory(form=evaluation, user=user)
+
+    has_unanswered_evaluations = user.has_unanswered_evaluations()
+
+    assert not has_unanswered_evaluations
+
+
+def test_has_unanswered_evaluations_when_has_unanswered_evaluations_returns_false(
+    user,
+):
+    evaluation = EventFormFactory(type=EventFormType.EVALUATION)
+    RegistrationFactory(event=evaluation.event, user=user, has_attended=True)
+
+    has_unanswered_evaluations = user.has_unanswered_evaluations()
+
+    assert has_unanswered_evaluations

--- a/app/settings.py
+++ b/app/settings.py
@@ -261,3 +261,8 @@ LOGGING = {
 }
 
 CELERY_BROKER_URL = os.environ.get("CELERY_URL")
+
+# Custom switches
+RESTRICT_REGISTRATION_FOR_UNANSWERED_EVALUATION = os.environ.get(
+    "switches" ".restrict_registration_for_unanswered_evaluation", False
+)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -16,7 +16,7 @@ from app.content.factories import (
     ShortLinkFactory,
     UserFactory,
 )
-from app.forms.tests.form_factories import FormFactory
+from app.forms.tests.form_factories import FormFactory, SubmissionFactory
 from app.group.factories import GroupFactory, MembershipFactory
 from app.util.test_utils import add_user_to_group_with_name, get_api_client
 
@@ -29,6 +29,24 @@ def request_factory():
 @pytest.fixture()
 def default_client():
     return get_api_client()
+
+
+@pytest.fixture
+def api_client():
+    """
+    Provide a callable fixture that returns an `APIClient` object.
+    If a user is provided when calling the fixture,
+    the client will be authenticated on behalf of it.
+
+    `api_client()` -> anonymous request
+    `api_client(user=user)` -> authenticated request
+    `api_client(user=user, group_name=group_name)` -> authenticated request with group permissions
+    """
+
+    def _get_api_client(user=None, group_name=None):
+        return get_api_client(user=user, group_name=group_name)
+
+    return _get_api_client
 
 
 @pytest.fixture()
@@ -104,6 +122,11 @@ def parent_page():
 @pytest.fixture()
 def form():
     return FormFactory()
+
+
+@pytest.fixture()
+def submission(form):
+    return SubmissionFactory(form=form)
 
 
 @pytest.fixture()

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -11,6 +11,8 @@ from app.content.factories import (
     RegistrationFactory,
     UserFactory,
 )
+from app.forms.enums import EventFormType
+from app.forms.tests.form_factories import EventFormFactory, SubmissionFactory
 from app.util.test_utils import get_api_client
 from app.util.utils import today
 
@@ -652,3 +654,34 @@ def test_delete_own_registration_as_member_when_no_users_on_wait_are_in_a_priori
     registration_on_wait.refresh_from_db()
 
     assert not registration_on_wait.is_on_wait
+
+
+@pytest.mark.django_db
+def test_that_users_cannot_register_when_has_unanswered_evaluations(api_client, user):
+    evaluation = EventFormFactory(type=EventFormType.EVALUATION)
+    RegistrationFactory(event=evaluation.event, user=user, has_attended=True)
+
+    next_event = EventFactory()
+
+    data = _get_registration_post_data(user, next_event)
+    url = _get_registration_url(event=next_event)
+    response = api_client(user=user).post(url, data=data)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert not next_event.registrations.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_that_users_can_register_when_has_no_unanswered_evaluations(api_client, user):
+    evaluation = EventFormFactory(type=EventFormType.EVALUATION)
+    RegistrationFactory(event=evaluation.event, user=user, has_attended=True)
+    SubmissionFactory(form=evaluation, user=user)
+
+    next_event = EventFactory()
+
+    data = _get_registration_post_data(user, next_event)
+    url = _get_registration_url(event=next_event)
+    response = api_client(user=user).post(url, data=data)
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert next_event.registrations.filter(user=user).exists()

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.test import override_settings
 from rest_framework import status
 
 import pytest
@@ -656,6 +657,7 @@ def test_delete_own_registration_as_member_when_no_users_on_wait_are_in_a_priori
     assert not registration_on_wait.is_on_wait
 
 
+@override_settings(RESTRICT_REGISTRATION_FOR_UNANSWERED_EVALUATION=True)
 @pytest.mark.django_db
 def test_that_users_cannot_register_when_has_unanswered_evaluations(api_client, user):
     evaluation = EventFormFactory(type=EventFormType.EVALUATION)
@@ -671,6 +673,7 @@ def test_that_users_cannot_register_when_has_unanswered_evaluations(api_client, 
     assert not next_event.registrations.filter(user=user).exists()
 
 
+@override_settings(RESTRICT_REGISTRATION_FOR_UNANSWERED_EVALUATION=True)
 @pytest.mark.django_db
 def test_that_users_can_register_when_has_no_unanswered_evaluations(api_client, user):
     evaluation = EventFormFactory(type=EventFormType.EVALUATION)


### PR DESCRIPTION
~**Avventer svar på om det skal gjelde for både NoK og Sosialen sine arrangementer**~

## Proposed changes
Ikke tillat brukere med ubesvarte evalueringer å melde seg på arrangementer hvis de har et ubesvart evalueringsskjema. Dette styres av en bryter man kan styre med en miljøvariabel. Den er av frem til TIHLDE/Kvark#161 er utført.

Lagt til et felt når man henter ut ett event som angir om brukeren har det øvrige.

Issue number: closes #185 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments