### PR TITLE
feat(forms): add viewer has answered to form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Neste versjon
 - ✨ **Evalueringer** må bli besvart før neste påmelding.
+- ✨ **Skjemaer**. Legg ved info om bruker allerede har svart på et spørreskjema.
 
 ## Versjon 1.0.15 (15.09.2021)
 - 🦟 **Tidssoner**. Fikset bug der tidspunkter i eposter blir formatert med feil tidssone.

--- a/app/forms/serializers/forms.py
+++ b/app/forms/serializers/forms.py
@@ -35,6 +35,7 @@ class FieldSerializer(BaseModelSerializer):
 
 class FormSerializer(BaseModelSerializer):
     fields = FieldSerializer(many=True, required=False, allow_null=True)
+    viewer_has_answered = serializers.SerializerMethodField()
 
     class Meta:
         model = Form
@@ -42,7 +43,13 @@ class FormSerializer(BaseModelSerializer):
             "id",
             "title",
             "fields",
+            "viewer_has_answered",
         )
+
+    def get_viewer_has_answered(self, obj):
+        request = self.context.get("request", None)
+        if request and request.user:
+            return obj.submissions.filter(user=request.user).exists()
 
     @atomic
     def create(self, validated_data):
@@ -107,13 +114,7 @@ class FormSerializer(BaseModelSerializer):
 class EventFormSerializer(FormSerializer):
     class Meta:
         model = EventForm
-        fields = (
-            "id",
-            "title",
-            "event",
-            "fields",
-            "type",
-        )
+        fields = FormSerializer.Meta.fields + ("event", "type",)
 
 
 class FormInSubmissionSerializer(serializers.ModelSerializer):

--- a/app/tests/forms/test_form_integration.py
+++ b/app/tests/forms/test_form_integration.py
@@ -76,6 +76,7 @@ def test_list_forms_data(admin_user):
         "title": form.title,
         "event": form.event.id,
         "type": form.type.name,
+        "viewer_has_answered": False,
         "fields": [
             {
                 "id": str(field.id),


### PR DESCRIPTION
## Proposed changes

New field: `viewer_has_answered`

Issue number: closes #212 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
