### PR TITLE
feat(user): include own submissions in /me/forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@
 ---
 
 ## Neste versjon
-- ✨ **Evalueringer** må bli besvart før neste påmelding.
-- ⚡ **Skjemaer**. Legg ved mer info om arrangementet i spørrskjemaer tilknyttet et arrangement.
-- ⚡ **Skjemaer**. Alternativ på flervalgsspørsmål er nå sortert etter tittel.
-- ✨ **Skjemaer**. Legg ved info om bruker allerede har svart på et spørreskjema.
+- Skjemaer
+    - ✨ **Evalueringer** må bli besvart før neste påmelding.
+    - ⚡ **Alternativ på flervalgsspørsmål** er nå sortert etter tittel.
+    - ✨ **Egne skjemaer** kan nå hentes ut i eget endepunkt.
+    - ⚡ **Skjemaer**. Legg ved mer info om arrangementet i spørrskjemaer tilknyttet et arrangement.
+    - ✨ **Skjemaer**. Legg ved info om bruker allerede har svart på et spørreskjema.
 
 ## Versjon 1.0.15 (15.09.2021)
 - 🦟 **Tidssoner**. Fikset bug der tidspunkter i eposter blir formatert med feil tidssone.

--- a/app/common/mixins.py
+++ b/app/common/mixins.py
@@ -1,0 +1,5 @@
+class ActionMixin:
+    def paginate_response(self, data, serializer):
+        page = self.paginate_queryset(data)
+        serializer = serializer(page, many=True)
+        return self.get_paginated_response(serializer.data)

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -112,6 +112,12 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
 
     objects = UserManager()
 
+    @property
+    def forms(self):
+        from app.forms.models.forms import Form
+
+        return Form.objects.filter(submissions__user=self)
+
     def has_unanswered_evaluations(self):
         return self.get_unanswered_evaluations().exists()
 

--- a/app/tests/content/test_user_integration.py
+++ b/app/tests/content/test_user_integration.py
@@ -1,0 +1,80 @@
+from rest_framework import status
+
+import pytest
+
+from app.content.factories import RegistrationFactory
+from app.forms.enums import EventFormType
+from app.forms.tests.form_factories import EventFormFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _get_user_forms_url():
+    return "/api/v1/user/me/forms/"
+
+
+def test_list_user_forms_returns_all_answered_forms(api_client, submission):
+    user = submission.user
+
+    url = _get_user_forms_url()
+    client = api_client(user=user)
+    response = client.get(url).json()
+    results = response.get("results")
+
+    assert len(results) == 1
+
+    actual_form_id = results[0].get("id")
+    expected_form_id = str(submission.form.id)
+
+    assert actual_form_id == expected_form_id
+
+
+def test_list_user_forms_returns_status_200_ok(api_client, submission):
+    user = submission.user
+    client = api_client(user=user)
+    response = client.get(_get_user_forms_url())
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_list_user_forms_filter_on_unanswered_returns_all_unanswered_forms(
+    api_client, submission
+):
+    """Should return all unanswered evaluations for attended events."""
+    user = submission.user
+    unanswered_form = EventFormFactory(type=EventFormType.EVALUATION)
+    RegistrationFactory(user=user, event=unanswered_form.event, has_attended=True)
+
+    url = f"{_get_user_forms_url()}?unanswered=true"
+    client = api_client(user=user)
+    response = client.get(url).json()
+    results = response.get("results")
+
+    assert len(results) == 1
+
+    actual_form_id = results[0].get("id")
+    unanswered_form_id = str(unanswered_form.id)
+
+    assert actual_form_id == unanswered_form_id
+
+
+def test_list_user_forms_filter_on_answered_returns_all_answered_forms(
+    api_client, submission
+):
+    """Should return all answered evaluations for attended events."""
+    user = submission.user
+
+    unanswered_form = EventFormFactory(type=EventFormType.EVALUATION)
+    RegistrationFactory(user=user, event=unanswered_form.event, has_attended=True)
+
+    url = f"{_get_user_forms_url()}?unanswered=false"
+    client = api_client(user=user)
+    response = client.get(url).json()
+    results = response.get("results")
+
+    assert len(results) == 1
+
+    actual_form_id = results[0].get("id")
+    expected_form_id = str(submission.form.id)
+
+    assert actual_form_id == expected_form_id

--- a/app/util/utils.py
+++ b/app/util/utils.py
@@ -46,3 +46,21 @@ def disable_for_loaddata(signal_handler):
         signal_handler(*args, **kwargs)
 
     return wrapper
+
+
+class CaseInsensitiveBooleanQueryParam:
+    value = None
+
+    def __init__(self, value):
+        if value is not None:
+            value = value.lower()
+            if value == "true":
+                self.value = True
+            elif value == "false":
+                self.value = False
+
+    def __bool__(self):
+        return bool(self.value)
+
+    def __str__(self):
+        return f"<{self.__class__.__name__} object ({self.value})"


### PR DESCRIPTION
## Proposed changes
La til endepunktet `/users/me/forms/` hvor en bruker kan hente ut forms den har svart på, med filtrering på om det er ubesvart. Filtreringen vil bare filtrere ubesvarte evalueringer, siden dette er det eneste som kan tolkes som ubesvart og som fortsatt kan knyttes til en bruker.

La også til en `ActionMixin` som reduserer duplikat kode i `@action` metoder som kun returnerer paginert data.

Slettet også `app/forms/serializers/form.py` da denne var utdatert og ubrukt. 

Issue number: closes #201 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

