### PR TITLE
refactor(submissions): move unanswered evaluation fields for users and registrations

### DIFF
--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -115,6 +115,9 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
     def has_unanswered_evaluations(self):
         return self.get_unanswered_evaluations().exists()
 
+    def has_unanswered_evaluations_for(self, event):
+        return self.get_unanswered_evaluations().filter(event=event)
+
     def get_unanswered_evaluations(self):
         from app.forms.models.forms import EventForm, EventFormType
 

--- a/app/content/serializers/event.py
+++ b/app/content/serializers/event.py
@@ -13,7 +13,6 @@ class EventSerializer(serializers.ModelSerializer):
     registration_priorities = serializers.SerializerMethodField()
     evaluation = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
     survey = serializers.PrimaryKeyRelatedField(many=False, read_only=True)
-    viewer_has_unanswered_evaluations = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
@@ -42,7 +41,6 @@ class EventSerializer(serializers.ModelSerializer):
             "evaluation",
             "survey",
             "updated_at",
-            "viewer_has_unanswered_evaluations",
         )
 
         extra_kwargs = {
@@ -84,11 +82,6 @@ class EventSerializer(serializers.ModelSerializer):
             ]
         except Priority.DoesNotExist:
             return None
-
-    def get_viewer_has_unanswered_evaluations(self, obj):
-        request = self.context.get("request", None)
-        if request and request.user:
-            return request.user.has_unanswered_evaluations()
 
 
 class EventListSerializer(serializers.ModelSerializer):

--- a/app/content/serializers/registration.py
+++ b/app/content/serializers/registration.py
@@ -11,6 +11,7 @@ class RegistrationSerializer(BaseModelSerializer):
     user_info = UserListSerializer(source="user", read_only=True)
     survey_submission = serializers.SerializerMethodField()
     waiting_number = serializers.SerializerMethodField()
+    has_unanswered_evaluation = serializers.SerializerMethodField()
 
     class Meta:
         model = Registration
@@ -23,6 +24,7 @@ class RegistrationSerializer(BaseModelSerializer):
             "created_at",
             "survey_submission",
             "waiting_number",
+            "has_unanswered_evaluation",
         ]
 
     def get_survey_submission(self, obj):
@@ -31,3 +33,6 @@ class RegistrationSerializer(BaseModelSerializer):
 
     def get_waiting_number(self, obj):
         return obj.get_waiting_number()
+
+    def get_has_unanswered_evaluation(self, obj):
+        return obj.user.has_unanswered_evaluations_for(obj.event)

--- a/app/content/serializers/user.py
+++ b/app/content/serializers/user.py
@@ -27,6 +27,7 @@ class DefaultUserSerializer(serializers.ModelSerializer):
 class UserSerializer(serializers.ModelSerializer):
     unread_notifications = serializers.SerializerMethodField()
     permissions = DRYGlobalPermissionsField(actions=["write", "read"])
+    unanswered_evaluations_count = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -45,6 +46,7 @@ class UserSerializer(serializers.ModelSerializer):
             "tool",
             "app_token",
             "unread_notifications",
+            "unanswered_evaluations_count",
             "permissions",
         )
         read_only_fields = ("user_id",)
@@ -53,6 +55,9 @@ class UserSerializer(serializers.ModelSerializer):
     def get_unread_notifications(self, obj):
         """ Counts all unread notifications and returns the count """
         return Notification.objects.filter(user=obj, read=False).count()
+
+    def get_unanswered_evaluations_count(self, obj):
+        obj.get_unanswered_evaluations().count()
 
 
 class UserListSerializer(UserSerializer):


### PR DESCRIPTION
## Proposed changes
La til feltet `unanswered_evaluations_count` på `UserSerializer`, flyttet `viewer_has_unanswered_evaluation` til `RegistrationSerializer` og endret til at den gjelder kun for akkurat det arrangementet. Endret navn på siste til `has_unanswered_evaluation`.

Issue number: Ingen issue


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments
