### PR TITLE
fix(forms): unanswered_evaluations typos

### DIFF
--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -122,7 +122,7 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
         return self.get_unanswered_evaluations().exists()
 
     def has_unanswered_evaluations_for(self, event):
-        return self.get_unanswered_evaluations().filter(event=event)
+        return self.get_unanswered_evaluations().filter(event=event).exists()
 
     def get_unanswered_evaluations(self):
         from app.forms.models.forms import EventForm, EventFormType

--- a/app/content/serializers/user.py
+++ b/app/content/serializers/user.py
@@ -57,7 +57,7 @@ class UserSerializer(serializers.ModelSerializer):
         return Notification.objects.filter(user=obj, read=False).count()
 
     def get_unanswered_evaluations_count(self, obj):
-        obj.get_unanswered_evaluations().count()
+        return obj.get_unanswered_evaluations().count()
 
 
 class UserListSerializer(UserSerializer):


### PR DESCRIPTION
## Proposed changes
Fix issues with PR that went through QA a bit fast 😉 

- `has_unanswered_evaluations_for` now returns a boolean and not an array
- `get_unanswered_evaluations_count` now actually returns a number

Issue number: no issue


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
