### PR TITLE
refactor(registration): remove evaluation switches

### DIFF
--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
@@ -118,9 +117,7 @@ class Registration(BaseModel):
         return super(Registration, self).save(*args, **kwargs)
 
     def create(self):
-        if settings.RESTRICT_REGISTRATION_FOR_UNANSWERED_EVALUATION:
-            self._abort_for_unanswered_evaluations()
-
+        self._abort_for_unanswered_evaluations()
         self.strike_handler()
         self.clean()
         self.is_on_wait = self.event.is_full

--- a/app/settings.py
+++ b/app/settings.py
@@ -268,8 +268,3 @@ LOGGING = {
 }
 
 CELERY_BROKER_URL = os.environ.get("CELERY_URL")
-
-# Custom switches
-RESTRICT_REGISTRATION_FOR_UNANSWERED_EVALUATION = os.environ.get(
-    "switches" ".restrict_registration_for_unanswered_evaluation", False
-)

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from django.test import override_settings
 from rest_framework import status
 
 import pytest
@@ -657,7 +656,6 @@ def test_delete_own_registration_as_member_when_no_users_on_wait_are_in_a_priori
     assert not registration_on_wait.is_on_wait
 
 
-@override_settings(RESTRICT_REGISTRATION_FOR_UNANSWERED_EVALUATION=True)
 @pytest.mark.django_db
 def test_that_users_cannot_register_when_has_unanswered_evaluations(api_client, user):
     evaluation = EventFormFactory(type=EventFormType.EVALUATION)
@@ -673,7 +671,6 @@ def test_that_users_cannot_register_when_has_unanswered_evaluations(api_client, 
     assert not next_event.registrations.filter(user=user).exists()
 
 
-@override_settings(RESTRICT_REGISTRATION_FOR_UNANSWERED_EVALUATION=True)
 @pytest.mark.django_db
 def test_that_users_can_register_when_has_no_unanswered_evaluations(api_client, user):
     evaluation = EventFormFactory(type=EventFormType.EVALUATION)


### PR DESCRIPTION
## Proposed changes
Fjernet bryteren som styrer begrensninger i påmeldinger for brukere med med ubesvarte evalueringsskjemaer, da denne funksjonaliteten skal være inkludert overalt.

Issue number: Ingen issue


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments
