### PR TITLE
fix(forms): allow nok to view submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 
 ## Neste versjon
+- 🦟 **Spørreskjema**. Fikset bug der medlemmer av NoK ikke hadde tilgang til å redigere spørreskjemaer.
 - 🦟 **Prikk**. Påmeldte på venteliste får nå ikke lenger prikk
 
 ## Versjon 1.0.17 (24.09.2021)

--- a/app/forms/models/forms.py
+++ b/app/forms/models/forms.py
@@ -14,7 +14,7 @@ from app.util.models import BaseModel
 
 
 class Form(PolymorphicModel):
-    write_access = [AdminGroup.HS, AdminGroup.NOK, AdminGroup.INDEX]
+    write_access = [AdminGroup.HS, AdminGroup.NOK, AdminGroup.SOSIALEN, AdminGroup.INDEX]
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     title = models.CharField(max_length=200)
 
@@ -117,7 +117,7 @@ class Option(models.Model):
 
 
 class Submission(BaseModel, BasePermissionModel):
-    read_access = [AdminGroup.HS, AdminGroup.INDEX, AdminGroup.NOK]
+    read_access = [AdminGroup.HS, AdminGroup.INDEX, AdminGroup.SOSIALEN, AdminGroup.NOK]
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     form = models.ForeignKey(Form, on_delete=models.CASCADE, related_name="submissions")
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="submissions")

--- a/app/forms/models/forms.py
+++ b/app/forms/models/forms.py
@@ -117,7 +117,7 @@ class Option(models.Model):
 
 
 class Submission(BaseModel, BasePermissionModel):
-    read_access = AdminGroup.admin()
+    read_access = [AdminGroup.HS, AdminGroup.INDEX, AdminGroup.NOK]
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     form = models.ForeignKey(Form, on_delete=models.CASCADE, related_name="submissions")
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="submissions")

--- a/app/tests/forms/test_form_integration.py
+++ b/app/tests/forms/test_form_integration.py
@@ -485,8 +485,8 @@ def test_delete_form_as_member_is_not_permitted(member, form):
 @pytest.mark.parametrize(
     ("group_name", "expected_status_code"),
     [
-        (AdminGroup.SOSIALEN, status.HTTP_403_FORBIDDEN),
-        (AdminGroup.PROMO, status.HTTP_200_OK),
+        (AdminGroup.SOSIALEN, status.HTTP_200_OK),
+        (AdminGroup.PROMO, status.HTTP_403_FORBIDDEN),
         (AdminGroup.HS, status.HTTP_200_OK),
         (AdminGroup.INDEX, status.HTTP_200_OK),
         (AdminGroup.NOK, status.HTTP_200_OK),

--- a/app/tests/forms/test_form_integration.py
+++ b/app/tests/forms/test_form_integration.py
@@ -113,7 +113,7 @@ def test_list_forms_as_member_is_not_permitted(member):
         (AdminGroup.HS, status.HTTP_200_OK),
         (AdminGroup.INDEX, status.HTTP_200_OK),
         (AdminGroup.NOK, status.HTTP_200_OK),
-        (AdminGroup.SOSIALEN, status.HTTP_403_FORBIDDEN),
+        (AdminGroup.SOSIALEN, status.HTTP_200_OK),
         (AdminGroup.PROMO, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -282,7 +282,7 @@ def test_update_form_as_member_is_not_permitted(member, form):
         (AdminGroup.HS, status.HTTP_200_OK),
         (AdminGroup.INDEX, status.HTTP_200_OK),
         (AdminGroup.NOK, status.HTTP_200_OK),
-        (AdminGroup.SOSIALEN, status.HTTP_403_FORBIDDEN),
+        (AdminGroup.SOSIALEN, status.HTTP_200_OK),
         (AdminGroup.PROMO, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -486,7 +486,7 @@ def test_delete_form_as_member_is_not_permitted(member, form):
     ("group_name", "expected_status_code"),
     [
         (AdminGroup.SOSIALEN, status.HTTP_403_FORBIDDEN),
-        (AdminGroup.PROMO, status.HTTP_403_FORBIDDEN),
+        (AdminGroup.PROMO, status.HTTP_200_OK),
         (AdminGroup.HS, status.HTTP_200_OK),
         (AdminGroup.INDEX, status.HTTP_200_OK),
         (AdminGroup.NOK, status.HTTP_200_OK),


### PR DESCRIPTION
## Proposed changes
Members of NoK didn't have access to view submissions, this gives them access. We should probably create a better system for access handling in forms based on formtype and recourcetype

Issue number: closes issue mentioned in Slack


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
