### PR TITLE
refactor(strikes): restrict strike deletion to admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+- ⚡ **Prikker**. Kun Index og HS-medlemmer kan nå slette prikker.
+- ✨ **Prikker**. Brukere mottar nå varsel om at de har fått en ny prikk.
 ## Versjon 1.1.1 (11.10.2021)
 - ⚡ **Ytelse**. Produksjon kjører nå med Gunicorn og Uvicorn med flere workers for å bli enda raskere.
 - ⚡ **Avhengigheter**. Python er oppgradert til v3.9 og Django er oppdatert til v3.2.8.

--- a/app/content/models/category.py
+++ b/app/content/models/category.py
@@ -6,7 +6,7 @@ from app.util.models import BaseModel
 
 
 class Category(BaseModel, BasePermissionModel):
-    write_access = [AdminGroup.HS, AdminGroup.INDEX, AdminGroup.NOK, AdminGroup.PROMO]
+    write_access = AdminGroup.all()
     text = models.CharField(max_length=200, null=True)
 
     class Meta:

--- a/app/content/models/page.py
+++ b/app/content/models/page.py
@@ -12,7 +12,7 @@ from app.util.models import BaseModel, OptionalImage
 
 class Page(MPTTModel, OptionalImage, BaseModel, BasePermissionModel):
 
-    write_access = [AdminGroup.HS, AdminGroup.INDEX]
+    write_access = AdminGroup.admin()
 
     parent = TreeForeignKey(
         "self", null=True, blank=True, on_delete=models.CASCADE, related_name="children"

--- a/app/content/models/strike.py
+++ b/app/content/models/strike.py
@@ -16,7 +16,8 @@ STRIKE_DURATION_IN_DAYS = 20
 
 def get_active_strikes_query():
     return Q(
-        created_at__lte=today(),
+        # TODO: Remove the "+ timedelta(days=1)" after standarizing timezones
+        created_at__lte=today() + timedelta(days=1),
         created_at__gte=today() - timedelta(days=STRIKE_DURATION_IN_DAYS),
     )
 
@@ -76,19 +77,19 @@ class Strike(BaseModel, BasePermissionModel):
         return f"{self.user.first_name} {self.user.last_name} - {self.description} - {self.strike_size}"
 
     def save(self, *args, **kwargs):
-        # TODO: Kjør når prikksystem er lansert "offisielt"
-        # if self.created_at is None:
-        #     from app.util.mail_creator import MailCreator
-        #     from app.util.notifier import Notify
+        if self.created_at is None:
+            from app.util.mail_creator import MailCreator
+            from app.util.notifier import Notify
 
-        #     Notify([self.user], "Du har fått en prikk").send_email(
-        #         MailCreator("Du har fått en prikk")
-        #         .add_paragraph(f"Hei {self.user.first_name}!")
-        #         .add_paragraph(self.description)
-        #         .generate_string()
-        #     ).send_notification(
-        #         description=self.description,
-        #     )
+            strike_info = "Prikken varer i 20 dager. Ta kontakt med arrangøren om du er uenig. Konsekvenser kan sees i arrangementsreglene. Du kan finne dine aktive prikker og mer info om dem i profilen."
+
+            Notify([self.user], "Du har fått en prikk").send_email(
+                MailCreator("Du har fått en prikk")
+                .add_paragraph(f"Hei {self.user.first_name}!")
+                .add_paragraph(self.description)
+                .add_paragraph(strike_info)
+                .generate_string()
+            ).send_notification(description=f"{self.description}\n{strike_info}",)
         super(Strike, self).save(*args, **kwargs)
 
     @property
@@ -98,6 +99,10 @@ class Strike(BaseModel, BasePermissionModel):
     @property
     def expires_at(self):
         return self.created_at + timedelta(days=STRIKE_DURATION_IN_DAYS)
+
+    @classmethod
+    def has_destroy_permission(cls, request):
+        return check_has_access(AdminGroup.admin(), request)
 
     def has_object_read_permission(self, request):
         return self.user.user_id == request.id or check_has_access(

--- a/app/content/serializers/user.py
+++ b/app/content/serializers/user.py
@@ -26,7 +26,7 @@ class DefaultUserSerializer(serializers.ModelSerializer):
 
 class UserSerializer(serializers.ModelSerializer):
     unread_notifications = serializers.SerializerMethodField()
-    permissions = DRYGlobalPermissionsField(actions=["write", "read"])
+    permissions = DRYGlobalPermissionsField(actions=["write", "read", "destroy"])
     unanswered_evaluations_count = serializers.SerializerMethodField()
 
     class Meta:

--- a/app/group/models/group.py
+++ b/app/group/models/group.py
@@ -11,7 +11,7 @@ from app.util.models import BaseModel, OptionalImage
 class Group(OptionalImage, BaseModel, BasePermissionModel):
     """Model for Custom Groups"""
 
-    write_access = [AdminGroup.HS, AdminGroup.INDEX]
+    write_access = AdminGroup.admin()
     name = models.CharField(max_length=50)
     slug = models.SlugField(max_length=50, primary_key=True)
     description = models.TextField(max_length=1000, null=True, blank=True)

--- a/app/group/models/membership.py
+++ b/app/group/models/membership.py
@@ -43,7 +43,7 @@ class MembershipHistory(BaseModel):
 class Membership(BaseModel, BasePermissionModel):
     """Model for a Group Membership"""
 
-    write_access = [AdminGroup.HS, AdminGroup.INDEX]
+    write_access = AdminGroup.admin()
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="memberships")
     group = models.ForeignKey(
         Group, on_delete=models.CASCADE, related_name="memberships"


### PR DESCRIPTION
## Proposed changes
Added the ` + timedelta(days=1)` to `.active()` as I wasn't able to delete newly added stikes else. We should go through the application and standarize how we handle timezones. `expires_at` in strikes does for example return UTC time in the json.

Issue number: closes #283 , closes #245 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
