### PR TITLE
fix(timezones): standarize timezones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - ✨ **Digitalt fotalbum**. La til funksjonalitet for å legge til et fotoalbum.
 - ✨ **Prikk**.  Nedtellingstiden til prikker settes på vent med ferier.
 - ✨ **Rekkefølge på spørsmål** er nå lagt til.
+- 🦟 **Tidssoner**. Standarisert tidssoner.
 
 ## Versjon 1.1.2 (19.10.2021)
 - ⚡ **Arrangement** blir nå ikke overbooket når en person blir flyttet opp fra ventelisten.

--- a/app/career/factories/weekly_business_factory.py
+++ b/app/career/factories/weekly_business_factory.py
@@ -4,7 +4,7 @@ import factory
 from factory.django import DjangoModelFactory
 
 from app.career.models import WeeklyBusiness
-from app.util import today
+from app.util import now
 
 
 class WeeklyBusinessFactory(DjangoModelFactory):
@@ -14,5 +14,5 @@ class WeeklyBusinessFactory(DjangoModelFactory):
     business_name = factory.Faker("name")
     body = factory.Faker("sentence", nb_words=100, variable_nb_words=True)
 
-    year = today().year + 1
+    year = now().year + 1
     week = randint(1, 52)

--- a/app/career/models/weekly_business.py
+++ b/app/career/models/weekly_business.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from app.common.enums import AdminGroup
 from app.common.permissions import BasePermissionModel
-from app.util import today
+from app.util import now
 from app.util.models import BaseModel, OptionalImage
 
 
@@ -33,7 +33,7 @@ class WeeklyBusiness(BaseModel, OptionalImage, BasePermissionModel):
     def save(self, *args, **kwargs):
         if self.week < 1 or self.week > 52:
             raise ValueError("Uke må være mellom 1 og 52")
-        if self.year < today().year:
+        if self.year < now().year:
             raise ValueError("Ukens bedrift kan ikke opprettes i fortiden")
         try:
             if WeeklyBusiness.objects.get(week=self.week, year=self.year).id != self.id:

--- a/app/career/tests/test_weekly_business.py
+++ b/app/career/tests/test_weekly_business.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app.career.factories import WeeklyBusinessFactory
-from app.util import today
+from app.util import now
 
 
 @pytest.fixture()
@@ -118,7 +118,7 @@ def test_create_weekly_business_this_year(weekly_business):
     """
     Test if possible to create weekly_business object this year
     """
-    assert weekly_business.year == today().year + 1
+    assert weekly_business.year == now().year + 1
 
 
 @pytest.mark.django_db
@@ -126,8 +126,8 @@ def test_create_weekly_business_next_year():
     """
     Test if possible to create weekly_business object next year
     """
-    weekly_business = WeeklyBusinessFactory(year=(today().year) + 1)
-    assert weekly_business.year == (today().year) + 1
+    weekly_business = WeeklyBusinessFactory(year=(now().year) + 1)
+    assert weekly_business.year == (now().year) + 1
 
 
 @pytest.mark.django_db
@@ -136,5 +136,5 @@ def test_create_weekly_business_last_year():
     Test if possible to create weekly_business object last year
     """
     with pytest.raises(ValueError) as v_err:
-        WeeklyBusinessFactory(year=(today().year) - 1)
+        WeeklyBusinessFactory(year=(now().year) - 1)
     assert "Ukens bedrift kan ikke opprettes i fortiden" == str(v_err.value)

--- a/app/career/views/weekly_business.py
+++ b/app/career/views/weekly_business.py
@@ -7,7 +7,7 @@ from app.career.models import WeeklyBusiness
 from app.career.serializers import WeeklyBusinessSerializer
 from app.common.pagination import BasePagination
 from app.common.permissions import BasicViewPermission
-from app.util import today, week_nr
+from app.util import now, week_nr
 
 
 class WeeklyBusinessViewSet(viewsets.ModelViewSet):
@@ -25,13 +25,9 @@ class WeeklyBusinessViewSet(viewsets.ModelViewSet):
         if "expired" in self.request.query_params:
             return WeeklyBusiness.objects.all().order_by("year", "week")
         if "this_week" in self.request.query_params:
-            return WeeklyBusiness.objects.filter(
-                year=today().year, week=week_nr(today())
-            )
-        in_future_this_year_filter = Q(year=today().year) & Q(
-            week__gte=week_nr(today())
-        )
-        next_year_filter = Q(year__gt=today().year)
+            return WeeklyBusiness.objects.filter(year=now().year, week=week_nr(now()))
+        in_future_this_year_filter = Q(year=now().year) & Q(week__gte=week_nr(now()))
+        next_year_filter = Q(year__gt=now().year)
         return WeeklyBusiness.objects.filter(
             (in_future_this_year_filter) | next_year_filter
         ).order_by("year", "week")

--- a/app/content/filters/event.py
+++ b/app/content/filters/event.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-
 from django_filters.rest_framework import BooleanFilter, FilterSet
 
 from app.content.models import Event
-from app.util.utils import midday, yesterday
+from app.util.utils import midday, now, yesterday
 
 
 class EventFilter(FilterSet):
@@ -17,8 +15,8 @@ class EventFilter(FilterSet):
 
     def filter_expired(self, queryset, name, value):
         midday_yesterday = midday(yesterday())
-        midday_today = midday(datetime.now())
-        time = midday_today if midday_today < datetime.now() else midday_yesterday
+        midday_today = midday(now())
+        time = midday_today if midday_today < now() else midday_yesterday
         if value:
             return queryset.filter(end_date__lt=time).order_by("-start_date")
         return queryset.filter(end_date__gte=time).order_by("start_date")

--- a/app/content/models/event.py
+++ b/app/content/models/event.py
@@ -8,7 +8,7 @@ from app.common.enums import AdminGroup
 from app.common.permissions import BasePermissionModel
 from app.forms.enums import EventFormType
 from app.util.models import BaseModel, OptionalImage
-from app.util.utils import today, yesterday
+from app.util.utils import now, yesterday
 
 from ..signals import send_event_reminders
 from .category import Category
@@ -88,14 +88,14 @@ class Event(BaseModel, OptionalImage, BasePermissionModel):
 
     @property
     def is_past_sign_off_deadline(self):
-        return today() >= self.sign_off_deadline
+        return now() >= self.sign_off_deadline
 
     def is_two_hours_before_event_start(self):
-        return today() >= self.start_date - timedelta(hours=2)
+        return now() >= self.start_date - timedelta(hours=2)
 
     @property
     def event_has_ended(self):
-        return today() >= self.end_date
+        return now() >= self.end_date
 
     def has_waiting_list(self):
         return self.has_limit() and (self.is_full or self.get_waiting_list().exists())

--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -14,7 +14,7 @@ from app.content.exceptions import (
 )
 from app.content.models.strike import create_strike
 from app.forms.enums import EventFormType
-from app.util import EnumUtils, today
+from app.util import EnumUtils, now
 from app.util.mail_creator import MailCreator
 from app.util.models import BaseModel
 from app.util.notifier import Notify
@@ -142,7 +142,7 @@ class Registration(BaseModel, BasePermissionModel):
             hours_offset = 3
             if number_of_strikes >= 2:
                 hours_offset = 12
-            if not today() >= self.event.start_registration_at + timedelta(
+            if not now() >= self.event.start_registration_at + timedelta(
                 hours=hours_offset
             ):
                 raise StrikeError(
@@ -262,11 +262,11 @@ class Registration(BaseModel, BasePermissionModel):
         self.check_registration_has_ended()
 
     def check_registration_has_started(self):
-        if self.event.start_registration_at > today():
+        if self.event.start_registration_at > now():
             raise ValidationError("Påmeldingen har ikke åpnet enda")
 
     def check_registration_has_ended(self):
-        if self.event.end_registration_at < today():
+        if self.event.end_registration_at < now():
             raise ValidationError("Påmeldingsfristen har passert")
 
     def get_waiting_number(self):

--- a/app/content/signals.py
+++ b/app/content/signals.py
@@ -11,7 +11,7 @@ from app.content.tasks.event import (
     event_end_schedular,
     event_sign_off_deadline_schedular,
 )
-from app.util.utils import disable_for_loaddata, midday, today
+from app.util.utils import disable_for_loaddata, midday, now
 
 logger = logging.getLogger(__name__)
 
@@ -85,4 +85,4 @@ def sign_off_deadline_reminder(event):
 
 
 def isFuture(eta):
-    return eta > today()
+    return eta > now()

--- a/app/content/tests/test_event_model.py
+++ b/app/content/tests/test_event_model.py
@@ -1,11 +1,16 @@
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 
 import pytest
 
-from ..factories import EventFactory, PriorityFactory, RegistrationFactory
+from app.content.factories import (
+    EventFactory,
+    PriorityFactory,
+    RegistrationFactory,
+)
+from app.util.utils import now
 
 
 @pytest.fixture()
@@ -26,7 +31,7 @@ def priority():
 @pytest.mark.django_db
 def test_expired_when_event_has_not_expired(event):
     """Should return False when end date is before yesterday."""
-    event.end_date = datetime.now(tz=timezone.utc)
+    event.end_date = now()
 
     assert not event.expired
 
@@ -34,7 +39,7 @@ def test_expired_when_event_has_not_expired(event):
 @pytest.mark.django_db
 def test_expired_when_event_has_expired(event):
     """Should return True when end date is after yesterday."""
-    event.end_date = datetime.now(tz=timezone.utc) - timedelta(days=10)
+    event.end_date = now() - timedelta(days=10)
 
     assert event.expired
 
@@ -161,7 +166,7 @@ def test_clean_validates_date_times(mock_validate_start_end_registration_times, 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "start_registration_at, end_registration_at",
-    [(None, datetime.now()), (datetime.now(), None), (datetime.now(), datetime.now())],
+    [(None, now()), (now(), None), (now(), now())],
 )
 def test_check_sign_up_and_registration_times_when_event_does_not_have_sign_up_raises_error(
     event, start_registration_at, end_registration_at
@@ -180,11 +185,11 @@ def test_check_sign_up_and_registration_times_when_event_does_not_have_sign_up_r
     "start_registration_at, end_registration_at, sign_off_deadline",
     [
         (None, None, None),
-        (None, None, datetime.now()),
-        (None, datetime.now(), datetime.now()),
-        (datetime.now(), None, None),
-        (datetime.now(), None, datetime.now()),
-        (datetime.now(), datetime.now(), None),
+        (None, None, now()),
+        (None, now(), now()),
+        (now(), None, None),
+        (now(), None, now()),
+        (now(), now(), None),
     ],
 )
 def test_check_if_registration_is_not_set_when_event_has_signup_raises_error(
@@ -206,7 +211,7 @@ def test_check_sign_up_and_sign_off_deadline_when_no_sign_up_but_sign_off_deadli
 ):
     """Should raise ValidationError if event has sign off dead line but no sign up."""
     event.sign_up = False
-    event.sign_off_deadline = datetime.now()
+    event.sign_off_deadline = now()
 
     with pytest.raises(ValidationError):
         event.check_sign_up_and_sign_off_deadline()
@@ -215,8 +220,8 @@ def test_check_sign_up_and_sign_off_deadline_when_no_sign_up_but_sign_off_deadli
 @pytest.mark.django_db
 def test_check_start_time_is_before_end_registration(event):
     """Should raise ValidationError if event end date is before event start date."""
-    event.start_date = datetime.now()
-    event.end_registration_at = datetime.now() + timedelta(days=1)
+    event.start_date = now()
+    event.end_registration_at = now() + timedelta(days=1)
 
     with pytest.raises(ValidationError):
         event.check_start_time_is_before_end_registration()
@@ -225,8 +230,8 @@ def test_check_start_time_is_before_end_registration(event):
 @pytest.mark.django_db
 def test_check_start_registration_is_before_end_registration(event):
     """Should raise ValidationError if start time for registration is after registration end time."""
-    event.start_registration_at = datetime.now()
-    event.end_registration_at = datetime.now() - timedelta(days=1)
+    event.start_registration_at = now()
+    event.end_registration_at = now() - timedelta(days=1)
 
     with pytest.raises(ValidationError):
         event.check_start_registration_is_before_end_registration()
@@ -235,8 +240,8 @@ def test_check_start_registration_is_before_end_registration(event):
 @pytest.mark.django_db
 def test_check_start_registration_is_after_start_time(event):
     """Should raise ValidationError if registration start time is after event start time."""
-    event.start_date = datetime.now()
-    event.start_registration_at = datetime.now() + timedelta(days=1)
+    event.start_date = now()
+    event.start_registration_at = now() + timedelta(days=1)
 
     with pytest.raises(ValidationError):
         event.check_start_registration_is_after_start_time()
@@ -245,8 +250,8 @@ def test_check_start_registration_is_after_start_time(event):
 @pytest.mark.django_db
 def test_check_end_time_is_before_end_registration(event):
     """Should raise ValidationError if registration end time is after event end time."""
-    event.end_date = datetime.now()
-    event.end_registration_at = datetime.now() + timedelta(days=1)
+    event.end_date = now()
+    event.end_registration_at = now() + timedelta(days=1)
 
     with pytest.raises(ValidationError):
         event.check_end_time_is_before_end_registration()
@@ -255,8 +260,8 @@ def test_check_end_time_is_before_end_registration(event):
 @pytest.mark.django_db
 def test_check_start_date_is_before_deadline(event):
     """Should raise ValidationError if sign off deadline is after event start time."""
-    event.start_date = datetime.now()
-    event.sign_off_deadline = datetime.now() + timedelta(days=1)
+    event.start_date = now()
+    event.sign_off_deadline = now() + timedelta(days=1)
 
     with pytest.raises(ValidationError):
         event.check_start_date_is_before_deadline()
@@ -265,8 +270,8 @@ def test_check_start_date_is_before_deadline(event):
 @pytest.mark.django_db
 def test_check_start_registration_is_after_deadline(event):
     """Should raise ValidationError if sign off deadline is after registration start time."""
-    event.sign_off_deadline = datetime.now()
-    event.start_registration_at = datetime.now() + timedelta(days=1)
+    event.sign_off_deadline = now()
+    event.start_registration_at = now() + timedelta(days=1)
 
     with pytest.raises(ValidationError):
         event.check_start_registration_is_after_deadline()

--- a/app/content/tests/test_strike_model.py
+++ b/app/content/tests/test_strike_model.py
@@ -2,23 +2,24 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 from app.content.factories.strike_factory import StrikeFactory
+from app.util.utils import getTimezone
 
 
-@mock.patch("app.content.models.strike.today")
-def test_active_or_not_strike_with_freeze_through_holidays(mock_today):
+@mock.patch("app.content.models.strike.now")
+def test_active_or_not_strike_with_freeze_through_holidays(mock_now):
     """
-    Test that uses a mock function of today() and a specified
+    Test that uses a mock function of now() and a specified
     creation date to check if a strike is active or not on the
-    date made by the mocked today() function. This test can be
+    date made by the mocked now() function. This test can be
     especially used to check if a strike is active after a holiday
 
-    :mock_today: the mocked today() function\n
+    :mock_now: the mocked now() function\n
     :strike: Strike instance with modified creation date\n
     :assert: whether or not strike is active on specified day\n
     """
 
-    mock_today.return_value = datetime(2022, 1, 5)
-    strike = StrikeFactory.build(created_at=datetime(2021, 12, 7))
+    mock_now.return_value = datetime(2022, 1, 5, tzinfo=getTimezone())
+    strike = StrikeFactory.build(created_at=datetime(2021, 12, 7, tzinfo=getTimezone()))
 
     assert strike.active
 
@@ -37,7 +38,7 @@ def test_strike_offset_is_added_when_created_after_new_year():
     :assert: whether or not number of active days of strike is equal to number of days\n
     """
 
-    strike = StrikeFactory.build(created_at=datetime(2022, 1, 5))
+    strike = StrikeFactory.build(created_at=datetime(2022, 1, 5, tzinfo=getTimezone()))
 
     active_days = strike.expires_at - strike.created_at
 
@@ -60,7 +61,9 @@ def test_active_days_of_a_strike_with_freeze_through_holidays():
     :assert: whether or not number of active days of strike is equal to number of days\n
     """
 
-    strike = StrikeFactory.build(created_at=datetime(2021, 12, 24))
+    strike = StrikeFactory.build(
+        created_at=datetime(2021, 12, 24, tzinfo=getTimezone())
+    )
 
     active_days = strike.expires_at - strike.created_at
 
@@ -80,7 +83,9 @@ def test_year_of_expire_date_different_than_created_year_with_freeze_through_hol
     :assert: whether or not expired_year is one year after created_year\n
     """
 
-    strike = StrikeFactory.build(created_at=datetime(2021, 11, 30))
+    strike = StrikeFactory.build(
+        created_at=datetime(2021, 11, 30, tzinfo=getTimezone())
+    )
 
     created_year = strike.created_at.year
     expired_year = strike.expires_at.year

--- a/app/content/views/event.py
+++ b/app/content/views/event.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, status, viewsets
 from rest_framework.decorators import action
@@ -18,7 +16,7 @@ from app.content.serializers import (
 )
 from app.util.mail_creator import MailCreator
 from app.util.notifier import Notify
-from app.util.utils import midday, yesterday
+from app.util.utils import midday, now, yesterday
 
 
 class EventViewSet(viewsets.ModelViewSet):
@@ -41,8 +39,8 @@ class EventViewSet(viewsets.ModelViewSet):
             queryset = Event.objects.all()
         else:
             midday_yesterday = midday(yesterday())
-            midday_today = midday(datetime.now())
-            time = midday_today if midday_today < datetime.now() else midday_yesterday
+            midday_today = midday(now())
+            time = midday_today if midday_today < now() else midday_yesterday
             queryset = Event.objects.filter(end_date__gte=time)
 
         return queryset.select_related("category").order_by("start_date")

--- a/app/group/models/membership.py
+++ b/app/group/models/membership.py
@@ -8,7 +8,7 @@ from app.common.permissions import BasePermissionModel
 from app.content.models.user import User
 from app.group.models.group import Group
 from app.util.models import BaseModel
-from app.util.utils import today
+from app.util.utils import now
 
 
 class MembershipHistory(BaseModel):
@@ -40,7 +40,7 @@ class MembershipHistory(BaseModel):
             group=membership.group,
             membership_type=membership.membership_type,
             start_date=membership.created_at,
-            end_date=today(),
+            end_date=now(),
         )
 
 

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -14,7 +14,7 @@ from app.content.factories import (
 from app.forms.enums import EventFormType
 from app.forms.tests.form_factories import EventFormFactory, SubmissionFactory
 from app.util.test_utils import get_api_client
-from app.util.utils import today
+from app.util.utils import now
 
 API_EVENT_BASE_URL = "/api/v1/events/"
 
@@ -294,7 +294,7 @@ def test_create_when_event_does_not_have_signup(admin_user, member):
 @pytest.mark.django_db
 def test_create_when_event_registration_has_not_started(admin_user, member):
     """A registration is not possible if the events registration has not started."""
-    tomorrow = today() + timedelta(days=1)
+    tomorrow = now() + timedelta(days=1)
     event_registration_not_started = EventFactory(start_registration_at=tomorrow)
     data = _get_registration_post_data(member, event_registration_not_started)
 
@@ -308,7 +308,7 @@ def test_create_when_event_registration_has_not_started(admin_user, member):
 @pytest.mark.django_db
 def test_create_when_event_registration_has_ended(admin_user, member):
     """A registration is not possible if the events registration has ended."""
-    yesterday = today() - timedelta(days=1)
+    yesterday = now() - timedelta(days=1)
     event_registration_not_started = EventFactory(end_registration_at=yesterday)
     data = _get_registration_post_data(member, event_registration_not_started)
 
@@ -589,7 +589,7 @@ def test_delete_as_member_when_sign_off_deadline_has_passed_and_not_on_wait(memb
     A member should be able to delete their registration
     when the events sign off deadline has passed and is not on wait within one hour.
     """
-    event = EventFactory(sign_off_deadline=today() - timedelta(days=1), limit=10)
+    event = EventFactory(sign_off_deadline=now() - timedelta(days=1), limit=10)
     registration = RegistrationFactory(user=member, event=event, is_on_wait=False)
     client = get_api_client(user=member)
 
@@ -605,7 +605,7 @@ def test_delete_as_member_when_sign_off_deadline_has_passed_and_on_wait(member):
     A member should be able to delete their registration
     when the events sign off deadline has passed but is on wait.
     """
-    event = EventFactory(sign_off_deadline=today() - timedelta(days=1))
+    event = EventFactory(sign_off_deadline=now() - timedelta(days=1))
     registration = RegistrationFactory(user=member, event=event)
     client = get_api_client(user=member)
 
@@ -647,7 +647,7 @@ def test_delete_another_registration_as_admin_after_sign_off_deadline(
     admin_user, member
 ):
     """An admin user should be able to delete any registration after sign off deadline."""
-    event = EventFactory(sign_off_deadline=today() - timedelta(days=1))
+    event = EventFactory(sign_off_deadline=now() - timedelta(days=1))
     registration = RegistrationFactory(user=member, event=event)
     client = get_api_client(user=admin_user)
 

--- a/app/tests/weekly_business/test_weekly_business_integration.py
+++ b/app/tests/weekly_business/test_weekly_business_integration.py
@@ -7,7 +7,7 @@ import pytest
 from app.career.factories import WeeklyBusinessFactory
 from app.common.enums import AdminGroup
 from app.content.factories.user_factory import UserFactory
-from app.util import today
+from app.util import now
 from app.util.test_utils import get_api_client
 
 API_WEEKLY_BUSINESS_BASE_URL = "/api/v1/weekly-business/"
@@ -28,7 +28,7 @@ def weekly_business_post_data():
         "image_alt": "index_logo",
         "business_name": "Index",
         "body": "Lorem ipsum penum rektum benedikt gagge",
-        "year": today().year + 1,
+        "year": now().year + 1,
         "week": randint(1, 52),
     }
 
@@ -47,9 +47,9 @@ def _get_weekly_business_put_data(weekly_business):
 @pytest.mark.django_db
 def test_weekly_business_ordering(default_client):
     """weekly_business should be ordered by year then week"""
-    oldest = WeeklyBusinessFactory(year=today().year + 1, week=2)
-    middel = WeeklyBusinessFactory(year=today().year + 1, week=10)
-    newest = WeeklyBusinessFactory(year=today().year + 2, week=4)
+    oldest = WeeklyBusinessFactory(year=now().year + 1, week=2)
+    middel = WeeklyBusinessFactory(year=now().year + 1, week=10)
+    newest = WeeklyBusinessFactory(year=now().year + 2, week=4)
 
     response = default_client.get(_get_weekly_business_url())
     response = response.json()

--- a/app/util/__init__.py
+++ b/app/util/__init__.py
@@ -1,2 +1,2 @@
 from app.util.enum_utils import EnumUtils
-from app.util.utils import today, yesterday, disable_for_loaddata, week_nr
+from app.util.utils import now, yesterday, disable_for_loaddata, week_nr

--- a/app/util/utils.py
+++ b/app/util/utils.py
@@ -2,17 +2,23 @@ import logging
 from datetime import datetime, timedelta
 from functools import wraps
 
+from django.conf import settings
+
 from pytz import timezone as pytz_timezone
 
 logger = logging.getLogger(__name__)
 
 
+def getTimezone():
+    return pytz_timezone(settings.TIME_ZONE)
+
+
 def yesterday():
-    return datetime.now(tz=pytz_timezone("Europe/Oslo")) - timedelta(days=1)
+    return now() - timedelta(days=1)
 
 
-def today():
-    return datetime.now(tz=pytz_timezone("Europe/Oslo"))
+def now():
+    return datetime.now(tz=getTimezone())
 
 
 def datetime_format(date_time):


### PR DESCRIPTION
## Proposed changes

One currently gets 500 Internal Server error when trying to get strikes from a user with more than 0 strikes. This was because of a compare of timezone-aware date and not-timezone aware date in strikes when finding the expiry-date (introduced in #300 ). The bug also blocked creating new strikes.

![image](https://user-images.githubusercontent.com/31009729/139421503-f1120505-957d-4f41-9f29-687f786f8b1b.png)

Did also rename the `today()` util-function to `now()` is I think its a more correct name. Edited all occurences of `datetime` to also provide timezone-info with the new util-function `getTimezone()`. This also fixed the `Event.end_date receieved a naive datetime` console-warning.

### Must be merged into dev **before** merging #309 so we don't break production !


Issue number: closes N/A


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
