### PR TITLE
hotfix(registration): set attended when event has queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+- 🦟 **Arrangement**. Fikset bug der admins ikke kunne melde påmeldte som ankommet hvis noen var på ventelisten.
+
 ## Versjon 1.1.3 (28.10.2021)
 - ✨ **Digitalt fotalbum**. La til funksjonalitet for å legge til et fotoalbum.
 - ✨ **Prikk**.  Nedtellingstiden til prikker settes på vent med ferier.

--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -118,13 +118,10 @@ class Registration(BaseModel, BasePermissionModel):
             self.create()
         self.send_notification_and_mail()
 
-        response = super(Registration, self).save(*args, **kwargs)
-
-        event = self.event
-        if event.has_limit() and event.get_queue().count() > event.limit:
+        if self.event.is_full and not self.is_on_wait and self in self.event.get_waiting_list():
             raise EventIsFullError
 
-        return response
+        return super(Registration, self).save(*args, **kwargs)
 
     def create(self):
         if self.event.enforces_previous_strikes:

--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
-from django.db.transaction import atomic
 
 from app.common.enums import AdminGroup, Groups, StrikeEnum
 from app.common.permissions import BasePermissionModel, check_has_access
@@ -112,7 +111,6 @@ class Registration(BaseModel, BasePermissionModel):
     def admin_unregister(self, *args, **kwargs):
         return super().delete(*args, **kwargs)
 
-    @atomic
     def save(self, *args, **kwargs):
         if not self.registration_id:
             self.create()

--- a/app/content/tests/test_registration_model.py
+++ b/app/content/tests/test_registration_model.py
@@ -464,3 +464,19 @@ def test_auto_bump_user_from_wait_does_not_increments_limit():
     event.refresh_from_db()
     assert not registration_on_wait.is_on_wait
     assert event.limit == limit
+
+
+@pytest.mark.django_db
+def test_set_attended_is_allowed_when_queue_exists():
+    """
+    Tests that admin can set participant as attended even if someone is on the waiting list
+    """
+    event = EventFactory(limit=1)
+    registration = RegistrationFactory(event=event)
+    RegistrationFactory(event=event, is_on_wait=True)
+    new_attended_state = True
+    registration.has_attended = new_attended_state
+
+    registration.save()
+
+    assert registration.has_attended == new_attended_state


### PR DESCRIPTION
## Proposed changes

Gjennom #292 kom det inn en bug som hindrer admins i å markere brukere som ankommet på et arrangement hvis det  er noen på arrangementets venteliste. Grunnen til det var at det ble sjekket om arrangementet hadde en venteliste, om det var fullt og om "Registration" som blir lagret `not is_on_wait`, isåfall ble det kastet en exception. Problemet her var at påmeldinger som allerede hadde plass og dermed ikke økte antall påmeldinger med plass også fikk denne exception ved save.

Har løst dette ved å gjøre `save` atomic, save registration og så sjekke om antall med plass er høyere enn limit. Hvis så kastes exeception og save av registration rulles tilbake.

Issue number: closes #


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Build (`make PR`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
