### PR TITLE
fix(strikes): get user strike

### DIFF
--- a/app/content/views/user.py
+++ b/app/content/views/user.py
@@ -143,14 +143,18 @@ class UserViewSet(viewsets.ModelViewSet, ActionMixin):
     @action(detail=False, methods=["get"], url_path="me/strikes")
     def get_user_strikes(self, request, *args, **kwargs):
         strikes = request.user.strikes.active()
-        serializer = UserInfoStrikeSerializer(instance=strikes, many=True, context={"request": request})
+        serializer = UserInfoStrikeSerializer(
+            instance=strikes, many=True, context={"request": request}
+        )
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["get"], url_path="strikes")
     def get_user_detail_strikes(self, request, *args, **kwargs):
         user = self.get_object()
         strikes = user.strikes.active()
-        serializer = UserInfoStrikeSerializer(instance=strikes, many=True, context={"request": request})
+        serializer = UserInfoStrikeSerializer(
+            instance=strikes, many=True, context={"request": request}
+        )
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["get"], url_path="me/events")

--- a/app/content/views/user.py
+++ b/app/content/views/user.py
@@ -143,14 +143,14 @@ class UserViewSet(viewsets.ModelViewSet, ActionMixin):
     @action(detail=False, methods=["get"], url_path="me/strikes")
     def get_user_strikes(self, request, *args, **kwargs):
         strikes = request.user.strikes.active()
-        serializer = UserInfoStrikeSerializer(instance=strikes, many=True)
+        serializer = UserInfoStrikeSerializer(instance=strikes, many=True, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["get"], url_path="strikes")
     def get_user_detail_strikes(self, request, *args, **kwargs):
         user = self.get_object()
         strikes = user.strikes.active()
-        serializer = UserInfoStrikeSerializer(instance=strikes, many=True)
+        serializer = UserInfoStrikeSerializer(instance=strikes, many=True, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["get"], url_path="me/events")


### PR DESCRIPTION
## Proposed changes

Fixes a bug where you couldn't load a user's strikes if any of the strikes where connected to an event which had an `organizer != None`. The bug came because the request wasn't passed as context to the serializer which needed it to add group permissions in response


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Format and lint (`make format` and `make flake8`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
