### PR TITLE
feat(fines): fines now sends out notifs and fine admins now gets an email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+- ✨ **Botsystem**. Medlemmer får nå et varsl når de får en ny bot.
+- ✨ **Botsjef**. Nye botsjefer får nå informasjon om sin nye roller på varsel og epost.
 - ✨ **Botsystem**. Grupper kan nå ha et botsystem og lovverk. Det er kun åpent for medlemmene og medlemmer kan gi bøter til hverandre.
 ## Versjon 1.2.1 (30.11.2021)
 - ✨ **Påmeldinger**. Brukere kan abonnere på sine påmeldinger til arrangementer gjennom kalenderen sin.

--- a/app/group/factories/group_factory.py
+++ b/app/group/factories/group_factory.py
@@ -2,6 +2,7 @@ import factory
 from factory.django import DjangoModelFactory
 
 from app.common.enums import GroupType
+from app.content.factories.user_factory import UserFactory
 from app.group.models import Group
 
 
@@ -19,3 +20,4 @@ class GroupFactory(DjangoModelFactory):
     )
     type = GroupType.SUBGROUP
     fines_activated = True
+    fines_admin = factory.SubFactory(UserFactory)

--- a/app/group/models/fine.py
+++ b/app/group/models/fine.py
@@ -40,9 +40,22 @@ class Fine(BaseModel, BasePermissionModel):
             raise UserIsNotInGroup(
                 f"{self.user.first_name} {self.user.last_name} er ikke medlem i gruppen"
             )
+        if not self.id:
+            self.notify_user()
+
+    def notify_user(self):
+        from app.util.notifier import Notify
+
+        Notify(
+            [self.user], f"Du har fått en bot i gruppen {self.group.name}"
+        ).send_notification(
+            description=f'{self.created_by.first_name} {self.created_by.last_name} har gitt deg {self.amount} bøter for å ha brutt paragraf "{self.description}" i gruppen {self.group.name}',
+            link=f"/grupper/{self.group.slug}/boter/",
+        )
 
     def save(self, *args, **kwargs):
         self.full_clean()
+
         return super().save(*args, **kwargs)
 
     @classmethod

--- a/app/group/serializers/fine.py
+++ b/app/group/serializers/fine.py
@@ -40,7 +40,15 @@ class FineUpdateCreateSerializer(BaseModelSerializer):
     class Meta:
         model = Fine
         list_serializer_class = FineListSerializer
-        fields = ("id", "user", "group", "amount", "description", "created_at")
+        fields = (
+            "id",
+            "user",
+            "group",
+            "amount",
+            "description",
+            "created_at",
+            "reason",
+        )
 
         read_only_fields = (
             "user",

--- a/app/group/tests/test_group_model.py
+++ b/app/group/tests/test_group_model.py
@@ -1,0 +1,31 @@
+import pytest
+
+from app.content.factories.user_factory import UserFactory
+from app.group.factories.group_factory import GroupFactory
+
+
+@pytest.fixture()
+def user():
+    return UserFactory()
+
+
+@pytest.fixture()
+def group():
+    return GroupFactory()
+
+
+@pytest.mark.django_db
+def test_check_fines_admin_does_not_send_mail_if_no_update(group):
+    assert not group.check_fine_admin()
+
+
+@pytest.mark.django_db
+def test_check_fines_admin_does_sends_mail_if_update(group, user):
+    group.fines_admin = user
+    assert group.check_fine_admin()
+
+
+@pytest.mark.django_db
+def test_check_fines_admin_does_not_send_mail_if_admin_is_none(group):
+    group.fines_admin = None
+    assert not group.check_fine_admin()

--- a/app/group/views/membership.py
+++ b/app/group/views/membership.py
@@ -57,10 +57,7 @@ class MembershipViewSet(viewsets.ModelViewSet):
                     MailCreator(title)
                     .add_paragraph(f"Hei {membership.user.first_name}!")
                     .add_paragraph(description)
-                    .add_button(
-                        "Se gruppen",
-                        f"{settings.WEBSITE_URL}/grupper/{membership.group.slug}/",
-                    )
+                    .add_button("Se gruppen", membership.group.website_url,)
                     .generate_string()
                 ).send_notification(
                     description=description, link=f"/grupper/{membership.group.slug}/",


### PR DESCRIPTION
## Proposed changes
Added notifications when creating a fine, and if a user is promoted to fines admin they are sendt an email with information about their new role

Issue number: closes #364 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The fixtures have been updated if needed (for migrations)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Format and lint (`make format` and `make flake8`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
