### PR TITLE
chore(github): reuse workflows, issue templates and changelog versioning

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: File a bug report
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen? Feel free to paste images of the bug!
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: dropdown
+    id: users
+    attributes:
+      label: Which users are seeing the problem?
+      multiple: true
+      options:
+        - Superadmins (Index)
+        - Admins (HS)
+        - Logged in users
+        - Anonymous users
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output, console.log or network errors for example. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Join our Slack
+    url: https://tihlde.slack.com/
+    about: Ask questions and get support
+  - name: Contact
+    url: https://tihlde.org/wiki/kontakt-oss/
+    about: Different ways of contacting TIHLDE

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,16 @@
+name: Feature request
+description: Request new features to be added
+labels: [new feature]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Feature request
+      description: |
+        Let us know what functionality you'd like to see in Lepton and what is your use case.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor_suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_suggestion.yml
@@ -1,0 +1,16 @@
+name: Refactor suggestion
+description: Add a suggestion for something that could be refactored
+labels: [refactor]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this refactor suggestion!
+  - type: textarea
+    id: what-can-be-refactored
+    attributes:
+      label: Refactor suggestion
+      description: |
+        Let us know what could be refactored/improved in Lepton and optionally why it should be done.
+    validations:
+      required: true

--- a/.github/scripts/changelogger.py
+++ b/.github/scripts/changelogger.py
@@ -4,7 +4,6 @@ file_path = "CHANGELOG.md"
 
 file_data = None
 next = None
-version = None
 with open(file_path, "r") as f:
     file_data = f.readlines()
     for i in range(len(file_data)):
@@ -12,20 +11,11 @@ with open(file_path, "r") as f:
         if "## Neste versjon" == line:
             next = i+1
         if "## Versjon" in line:
-            version = line.split(" ")[2].split(".")
             break
 
-last_index = len(version)-1
-version[last_index] = str(int(version[last_index]) + 1)
-for i in range(last_index, 0, -1):
-    if int(version[i]) > 99:
-        version[i] = "0"
-        version[i-1] = str(int(version[i-1]) + 1)
-version = '.'.join(version)
-
-today = datetime.now().strftime("%d.%m.%Y")
+today = datetime.now().strftime("%Y.%m.%d")
 file_data.insert(
-    next, f"## Versjon {version} ({today})\n")
+    next, f"## Versjon {today}\n")
 with open(file_path, "w") as f:
     file_data = "".join(file_data)
     f.write(file_data)

--- a/.github/workflows/changelogger.yml
+++ b/.github/workflows/changelogger.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Iterate CHANGELOG
         run: |
-          python .github/scripts/changeloger.py
+          python .github/scripts/changelogger.py
         
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -7,38 +7,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
-    runs-on: 'ubuntu-latest'
-
-    steps:
-    - uses: actions/checkout@master
-
-    - uses: azure/docker-login@v1
-      with:
-        login-server: https://leptondevregistry.azurecr.io/
-        username: ${{ secrets.ACI_DEV_USERNAME }}
-        password: ${{ secrets.ACI_DEV_PASSWORD }}
-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
-    - name: Build and push
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        context: ./
-        file: ./compose/Dockerfile
-        builder: ${{ steps.buildx.outputs.name }}
-        push: true
-        tags: leptondevregistry.azurecr.io/lepton:latest
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+  deploy:
+    uses: TIHLDE/Lepton/.github/workflows/deploy_to_azure.yml@dev
+    with:
+      registry_name: leptondevregistry
+    secrets:
+      registry_username: ${{ secrets.ACI_DEV_USERNAME }}
+      registry_password: ${{ secrets.ACI_DEV_PASSWORD }}

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -7,38 +7,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
-    runs-on: 'ubuntu-latest'
-
-    steps:
-    - uses: actions/checkout@master
-
-    - uses: azure/docker-login@v1
-      with:
-        login-server: https://leptonregistry.azurecr.io/
-        username: ${{ secrets.ACI_PROD_USERNAME }}
-        password: ${{ secrets.ACI_PROD_PASSWORD }}
-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
-    - name: Build and push
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        context: ./
-        file: ./compose/Dockerfile
-        builder: ${{ steps.buildx.outputs.name }}
-        push: true
-        tags: leptonregistry.azurecr.io/lepton:latest
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
+  deploy:
+    uses: TIHLDE/Lepton/.github/workflows/deploy_to_azure.yml@master
+    with:
+      registry_name: leptonregistry
+    secrets:
+      registry_username: ${{ secrets.ACI_PROD_USERNAME }}
+      registry_password: ${{ secrets.ACI_PROD_PASSWORD }}

--- a/.github/workflows/deploy_to_azure.yml
+++ b/.github/workflows/deploy_to_azure.yml
@@ -1,0 +1,50 @@
+
+name: Deploy to Azure
+
+on:
+  workflow_call:
+    inputs:
+      registry_name:
+        required: true
+        type: string
+    secrets:
+      registry_username:
+        required: true
+      registry_password:
+        required: true
+    
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: azure/docker-login@v1
+      with:
+        login-server: https://${{ inputs.registry_name }}.azurecr.io/
+        username: ${{ secrets.registry_username }}
+        password: ${{ secrets.registry_password }}
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./compose/Dockerfile
+        builder: ${{ steps.buildx.outputs.name }}
+        push: true
+        tags: ${{ inputs.registry_name }}.azurecr.io/lepton:latest
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,32 +17,32 @@
 - ✨ **Botsystem**. Medlemmer får nå et varsl når de får en ny bot.
 - ✨ **Botsjef**. Nye botsjefer får nå informasjon om sin nye roller på varsel og epost.
 - ✨ **Botsystem**. Grupper kan nå ha et botsystem og lovverk. Det er kun åpent for medlemmene og medlemmer kan gi bøter til hverandre.
-## Versjon 1.2.1 (30.11.2021)
+## Versjon 2021.11.30
 - ✨ **Påmeldinger**. Brukere kan abonnere på sine påmeldinger til arrangementer gjennom kalenderen sin.
 - ✨ **Sider**. Lagt til plassering og rekkefølge på sider.
 - ✨ **Gruppeskjemaer** kan nå bli opprettet av alle medlemmer av gruppen.
 
-## Versjon 1.2.0 (16.11.2021)
+## Versjon 2021.11.16
 - ⚡ **Grupper** har nå bilder.
 - ✨ **Brukere**. Studenter kan nå registrere kontoer med Informasjonsbehandling som studieprogram.
 - ✨ **Arrangementer**. Endret tilgangshåndtering til arrangementer ved å knytte dem til grupper. Dermed kan også ledere av komitéer og interessegrupper opprette arrangementer.
 
-## Versjon 1.1.5 (14.11.2021)
+## Versjon 2021.11.14
 - ⚡ **Arrangement**. Om en usvart evaluering er over 30 dager gammel, vil den ikke hindre deg i å melde deg på et arrangement.
 - ⚡ **Epost**. Støtter flere epost-leverandører gjennom mer universell formatering.
 - ✨ **Prioriteringer** En innstilling på arrangementer som gjør at kun prioriterte studenter kan melde seg på.
 - 🦟 **Svar på spørreskjemaer**. Fikset en bug der svar på spørreskjema ikke ble registrert.
 
-## Versjon 1.1.4 (01.11.2021)
+## Versjon 2021.11.01
 - 🦟 **Arrangement**. Fikset bug der admins ikke kunne melde påmeldte som ankommet hvis noen var på ventelisten.
 
-## Versjon 1.1.3 (28.10.2021)
+## Versjon 2021.10.28
 - ✨ **Digitalt fotalbum**. La til funksjonalitet for å legge til et fotoalbum.
 - ✨ **Prikk**.  Nedtellingstiden til prikker settes på vent med ferier.
 - ✨ **Rekkefølge på spørsmål** er nå lagt til.
 - 🦟 **Tidssoner**. Standarisert tidssoner.
 
-## Versjon 1.1.2 (19.10.2021)
+## Versjon 2021.10.19
 - ⚡ **Arrangement** blir nå ikke overbooket når en person blir flyttet opp fra ventelisten.
 - 🦟 **Bedrifter-skjema**. Fikset bug der bedrifts-skjema ikke ble sendt korrekt til NoK.
 - ✨ **Skjemamaler**. La inn støtte for skjemamaler.
@@ -53,24 +53,24 @@
 - ✨ **Prikker**. Brukere mottar nå varsel om at de har fått en ny prikk.
 - ⚡ **Spørreskjema**. Tekstfelt kan nå svares på med lengre tekst enn bare 255 tegn.
 
-## Versjon 1.1.1 (11.10.2021)
+## Versjon 2021.10.11
 - ⚡ **Ytelse**. Produksjon kjører nå med Gunicorn og Uvicorn med flere workers for å bli enda raskere.
 - ⚡ **Avhengigheter**. Python er oppgradert til v3.9 og Django er oppdatert til v3.2.8.
 - ✨ **Flower** Lagt til administrasjonspanel for Celery.
 
-## Versjon 1.1.0 (06.10.2021)
+## Versjon 2021.10.06
 - ⚡ **Ytelse**. Forbedret ytelsen på API'et gjennom blant annet mer caching, async eposter og andre forbedringer.
 
-## Versjon 1.0.18 (30.09.2021)
+## Versjon 2021.09.30
 - 🦟 **Arrangement**. Hent ut kun svar til spørreskjema for dem som ha plass på arrangementet.
 - 🦟 **Spørreskjema**. Fikset bug der medlemmer av NoK ikke hadde tilgang til å redigere spørreskjemaer.
 - 🦟 **Prikk**. Påmeldte på venteliste får nå ikke lenger prikk
 
-## Versjon 1.0.17 (24.09.2021)
+## Versjon 2021.09.24
 - ✨ **Svar på skjemaer** kan nå lastes ned som en csv-fil.
 - ⚡ **Maksgrensen på arrangementer** økes nå hvis en admin melder på noen og det er fullt.
 
-## Versjon 1.0.16 (21.09.2021)
+## Versjon 2021.09.21
 - Skjemaer
     - ✨ **Evalueringer** må bli besvart før neste påmelding.
     - ⚡ **Alternativ på flervalgsspørsmål** er nå sortert etter tittel.
@@ -78,67 +78,67 @@
     - ⚡ **Skjemaer**. Legg ved mer info om arrangementet i spørrskjemaer tilknyttet et arrangement.
     - ✨ **Skjemaer**. Legg ved info om bruker allerede har svart på et spørreskjema.
 
-## Versjon 1.0.15 (15.09.2021)
+## Versjon 2021.09.15
 - 🦟 **Tidssoner**. Fikset bug der tidspunkter i eposter blir formatert med feil tidssone.
 
-## Versjon 1.0.14 (12.09.2021)
+## Versjon 2021.09.12
 - ✨ **Svar på spørreskjemaer** blir nå sendt med sammen med påmeldingen.
 - ✨ **Statistikk spørreskjemaer** Kan nå hente ut statistikk over svar på spørreskjemaer.
 
-## Versjon 1.0.13 (06.09.2021)
+## Versjon 2021.09.06
 - ✨ **Svar på spørreskjemaer** Medlemmer kan nå svare på spørreskjemaer.
 - ✨ **Grupper** Ledere for undergrupper blir nå automagisk medlem av hs gruppen
 
-## Versjon 1.0.12 (22.08.2021)
+## Versjon 2021.08.22
 - 🦟 **Celery**. Fikset problem der oppdatering av arrangement førte til evig rekursjon.
 - ✨ **Varsler**. Varsler kan nå inneholder linker til relevant innhold.
 - ✨ **Arrangement-melding**. Arrangører av arrangementer kan sende ut epost/varsel til de påmeldte deltagerne.
 - ⚡ **Bedrifter**. Finere epost fra bedrifter til mottager.
-## Versjon 1.0.11 (11.08.2021)
+## Versjon 2021.08.11
 - ✨ **Brukere**. Admins kan nå slette nye "ventende" brukere og legge ved en begrunnelse.
 - 🦟 **Celery**. Fikset Celery tasks slik at man ikke kjører samme flere ganger lengre.
 - 🦟 **Bruker**. Når admin oppdaterer egen bruker så kommer nå samme data tilbake som for vanlige medlemmer.
-## Versjon 1.0.10 (10.05.2021)
+## Versjon 2021.05.10
 - ⚡ **Bruker** Lagt til egne endpunkter for å hente ut relatert bruker data
-## Versjon 1.0.9 (05.05.2021)
+## Versjon 2021.05.05
 - ⚡ **Pages** Implementert søk i pages siden
 - ⚡ **Medlemskap**.Lagt til pagination på listing av medlemskap, og filtrering for å hente ut list med bare medlemmer.
 - ⚡ **Varsler**. Nye brukere får epost om at bruker er blitt godkjent. Brukere som blir lagt til i en gruppe får varsel.
 - 🦟 **Tilganger**. Fikset bug der HS ikke hadde tilgang til å aktivere nye brukere.
 - ✨ **Brukeradmin**. HS og Index har nå mulighet til å oppdatere brukerdata.
 
-## Versjon 1.0.8 (01.05.2021)
+## Versjon 2021.05.01
 - ⚡ **Brukere**. Fjernet felter fra brukere som hentes ut i liste, slik at forespørselen går raskere.
 - 🦟 **Påmelding**. Fikset bug der brukere ikke kunne avslå å bli avbildet på arrangementer.
 - 🦟 **Tilbakestilling av passord** tar brukeren til riktig side fremfor en som ikke finnes.
 
-## Versjon 1.0.7 (26.04.2021)
+## Versjon 2021.04.26
 - ⚡ **Azure**. Satt opp produksjon i Azure og automatisk oppdatering ved push til master.
 - ✨ **Endring i permissions**. Endret hvordan vi håndterer tillatelser på nettsiden til å bruke våre nye grupper.
 - ⚡ **Utvidede tillatelser**. Alle medlemmer av Sosialen og Promo kan nå legge ut arrangementer og nyheter.
 - ⚡ **Medlemskap i TIHLDE**. Sjekk av medlemskap i TIHLDE bruker nå medlemskap til grupper.
 
-## Versjon 1.0.6 (09.04.2021)
+## Versjon 2021.04.09
 - 🦟 **Oppdatert arrangement**. Fikset bug der det ikke var mulig å oppdatere arrangement.
 - ✨ **Azure**. Satt opp dev-miljø i Azure for å migrere vekk fra Drift og til skyen.
 - ✨ **Venteliste nummer**. Henter nå ut hvilken plass du er på i ventelisten
 - ✨ **Refusjons skjema**. Lagt til mulighet for å sende refusjons skjema rett til økonomiansvarlig, med kvittering.
 
-## Versjon 1.0.5 (24.03.2021)
+## Versjon 2021.03.24
 - 🦟 **Opprett arrangement**. Fikset feil der det ikke var mulig å opprette et arrangement.
 - ✨ **Logging** av endringer skjer automatisk ved bruk.
 - ✨ **Prikksystemet**. Da er det endelig laget endepunkter for prikksystemet, slik at admin kan nå hente, lage og slette prikker.
 
-## Versjon 1.0.4 (15.03.2021)
+## Versjon 2021.03.15
 - ✨ **Filopplastning**. Lagt til støtte for filopplastning til Azure gjennom eget endepunkt. Kun for medlemmer.
 - ✨ **Spørreskjemaer**. Admins kan opprette, redigere og slette spørreskjemaer. Disse kan brukes i blant annet arrangement-påmelding.
 
-## Versjon 1.0.3 (09.03.2021)
+## Versjon 2021.03.09
 - ⚡ **Pagination i varsler**. Lagt til pagination i varsler, samt lagt til tester og fjernet admin's muligheter til å opprette/endre/slette andres varsler.
 - ✨ **Korte URL's**. Opprettet en ny tjeneste der brukere kan lagre url'er bak korte, valgfrie slugs.
 - ✨ **Ukens Bedrift**. Nå er det mulig for NoK å lage en kø med ukens bedrifter basert på ukenr
 
-## Versjon 1.0.2 (22.02.2021)
+## Versjon 2021.02.22
 - 🦟 **Lås påmeldingstid i registrering**. Hindre at tidspunktet for påmelding endres når påmeldingen endres. Dermed beholder påmeldte sin prioritet i listen.
 - 🎨 **Nytt utseende i epost**. Oppdatert utseende i eposter som harmonierer med med resten av nettsiden.
 - 🦟 **Begrens epost-domener**. Hindre brukere i å lage bruker med @ntnu.no-adresser siden vi ikke klarer å sende epost til slike adresser.
@@ -149,8 +149,6 @@
 - 🦟 **Å melde seg av som adminbruker** flytter nå opp brukere på ventelisten, som forventet.
 - ⚡ **Bruker får bilde** som kan brukes som profilbilde på TIHLDE siden
 
-## Versjon 1.0.1 (09.02.2021)
+## Versjon 2021.02.09
 - ⚡ **Ryddet opp i event-felter**. Fjernet åpent tilgjengelig liste over deltagere, samt redusert antall felter som returneres når man henter flere.
 - 🦟 **Fikset utviklingsmiljø**. Fikset pipfile slik at Heroku-dev backend nå fungerer igjen.
-
-## Versjon 1.0.0 (01.02.2021)


### PR DESCRIPTION
## Proposed changes
- Makes use of the reusable workflows for continuous deployment
- Add issue templates
- Change versioning style. Now uses the format `Versjon YYYY.MM.dd`, eks: `Versjon 2021.05.23`
  - This is beacuse a semantic version doesn't make sense when we don't publish or make our api publicly available.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The fixtures have been updated if needed (for migrations)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Format and lint (`make format` and `make flake8`) was run locally without failures