### PR TITLE
feat(gdpr): user data export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 
 ## Neste versjon
+- ✨ **GDPR**. Muliggjort eksportering av alle brukers data. Blir sendt som zip-fil til brukers mail på forepørsel.
 ## Versjon 2022.01.15
 - ⚡ **Botsystem**. Lovverket er bedre sortert ved at paragraf-nummer nå lagres separat.
 - ⚡ **Epost**. Utsending av eposter er forhåpentligvis mye mer stabilt og loggbart nå.

--- a/app/communication/notifier.py
+++ b/app/communication/notifier.py
@@ -60,7 +60,7 @@ class Notify:
         return self
 
 
-def send_html_email(to_mails, html, subject):
+def send_html_email(to_mails, html, subject, attachments=None):
     """
     to_mails: str -> Email-addresses of receivers\n
     html: str -> The email HTML to be sent to the receivers\n
@@ -77,7 +77,11 @@ def send_html_email(to_mails, html, subject):
             text_content = strip_tags(html)
             email_sender = os.environ.get("EMAIL_USER")
             msg = EmailMultiAlternatives(
-                subject, text_content, f"TIHLDE <{email_sender}>", bcc=mails
+                subject,
+                text_content,
+                f"TIHLDE <{email_sender}>",
+                bcc=mails,
+                attachments=attachments,
             )
             msg.attach_alternative(html, "text/html")
             result = msg.send()

--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -15,6 +15,7 @@ from app.content.exceptions import (
 )
 from app.content.models.event import Event
 from app.content.models.strike import create_strike
+from app.content.models.user import User
 from app.forms.enums import EventFormType
 from app.util import EnumUtils, now
 from app.util.mail_creator import MailCreator
@@ -34,10 +35,10 @@ class Registration(BaseModel, BasePermissionModel):
 
     registration_id = models.AutoField(primary_key=True)
     user = models.ForeignKey(
-        "content.User", on_delete=models.CASCADE, related_name="registrations"
+        User, on_delete=models.CASCADE, related_name="registrations"
     )
     event = models.ForeignKey(
-        "content.Event", on_delete=models.CASCADE, related_name="registrations"
+        Event, on_delete=models.CASCADE, related_name="registrations"
     )
 
     is_on_wait = models.BooleanField(default=False, verbose_name="waiting list")

--- a/app/content/models/strike.py
+++ b/app/content/models/strike.py
@@ -7,6 +7,7 @@ from django.db.models.aggregates import Sum
 
 from app.common.enums import AdminGroup
 from app.common.permissions import BasePermissionModel, check_has_access
+from app.content.models import Event
 from app.util.models import BaseModel
 from app.util.utils import getTimezone, now
 
@@ -60,11 +61,7 @@ class Strike(BaseModel, BasePermissionModel):
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="strikes"
     )
     event = models.ForeignKey(
-        "content.Event",
-        on_delete=models.SET_NULL,
-        blank=True,
-        null=True,
-        related_name="strikes",
+        Event, on_delete=models.SET_NULL, blank=True, null=True, related_name="strikes",
     )
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/app/content/views/user.py
+++ b/app/content/views/user.py
@@ -34,6 +34,7 @@ from app.content.serializers.strike import UserInfoStrikeSerializer
 from app.forms.serializers import FormPolymorphicSerializer
 from app.group.models import Group, Membership
 from app.group.serializers import GroupSerializer
+from app.util.export_user_data import export_user_data
 from app.util.mail_creator import MailCreator
 from app.util.utils import CaseInsensitiveBooleanQueryParam
 
@@ -244,4 +245,21 @@ class UserViewSet(viewsets.ModelViewSet, ActionMixin):
         return Response(
             {"detail": "Brukeren ble avslått og har blitt informert på epost"},
             status=status.HTTP_200_OK,
+        )
+
+    @action(detail=False, methods=["get"], url_path="me/data")
+    def export_user_data(self, request, *args, **kwargs):
+        export_successfull = export_user_data(request, request.user)
+
+        if export_successfull:
+            return Response(
+                {
+                    "detail": "Vi har sendt en epost til din registrerte epost-adresse med dine data vedlagt"
+                },
+                status=status.HTTP_200_OK,
+            )
+
+        return Response(
+            {"detail": "Noe gikk galt, prøv igjen senere eller kontakt Index"},
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )

--- a/app/forms/serializers/__init__.py
+++ b/app/forms/serializers/__init__.py
@@ -7,5 +7,13 @@ from app.forms.serializers.forms import (
     EventFormSerializer,
     OptionSerializer,
 )
+from app.forms.serializers.submission import (
+    AnswerSerializer,
+    BaseModelSerializer,
+    BaseSubmissionSerializer,
+    SubmissionInRegistrationSerializer,
+    SubmissionSerializer,
+    SubmissionGDPRSerializer,
+)
 
 from app.forms.serializers.statistics import FormStatisticsSerializer

--- a/app/forms/serializers/submission.py
+++ b/app/forms/serializers/submission.py
@@ -4,7 +4,11 @@ from rest_framework.exceptions import MethodNotAllowed
 from app.common.serializers import BaseModelSerializer
 from app.content.serializers.user import DefaultUserSerializer
 from app.forms.models import Answer, Field, Option, Submission
-from app.forms.serializers import FieldInAnswerSerializer, OptionSerializer
+from app.forms.serializers import (
+    FieldInAnswerSerializer,
+    FormPolymorphicSerializer,
+    OptionSerializer,
+)
 
 
 class AnswerSerializer(serializers.ModelSerializer):
@@ -77,3 +81,11 @@ class SubmissionInRegistrationSerializer(BaseSubmissionSerializer):
     class Meta:
         model = BaseSubmissionSerializer.Meta.model
         fields = BaseSubmissionSerializer.Meta.fields + ("form",)
+
+
+class SubmissionGDPRSerializer(SubmissionInRegistrationSerializer):
+    form = FormPolymorphicSerializer(read_only=True)
+
+    class Meta:
+        model = SubmissionInRegistrationSerializer.Meta.model
+        fields = SubmissionInRegistrationSerializer.Meta.fields

--- a/app/group/serializers/__init__.py
+++ b/app/group/serializers/__init__.py
@@ -4,3 +4,12 @@ from app.group.serializers.membership import (
     UpdateMembershipSerializer,
     MembershipHistorySerializer,
 )
+from app.group.serializers.fine import (
+    FineListSerializer,
+    FineNoUserSerializer,
+    FineSerializer,
+    FineStatisticsSerializer,
+    FineUpdateCreateSerializer,
+    UserFineSerializer,
+)
+from app.group.serializers.law import LawSerializer

--- a/app/tests/content/test_user_integration.py
+++ b/app/tests/content/test_user_integration.py
@@ -132,6 +132,7 @@ def test_filter_only_users_with_active_strikes(
         ("me/events/", status.HTTP_200_OK),
         ("me/forms/", status.HTTP_200_OK),
         ("me/strikes/", status.HTTP_200_OK),
+        ("me/data/", status.HTTP_200_OK),
     ],
 )
 def test_user_actions(url, status_code, user, api_client):

--- a/app/util/export_user_data.py
+++ b/app/util/export_user_data.py
@@ -1,0 +1,118 @@
+import tempfile
+import zipfile
+
+from django.contrib.admin.models import LogEntry
+from django.core import serializers
+from rest_framework.renderers import JSONRenderer
+
+from sentry_sdk import capture_exception
+
+from app.communication.notifier import send_html_email
+from app.content.models import Notification
+from app.content.serializers import (
+    NotificationSerializer,
+    RegistrationSerializer,
+    ShortLinkSerializer,
+    StrikeSerializer,
+    UserBadgeSerializer,
+    UserSerializer,
+)
+from app.forms.serializers import SubmissionGDPRSerializer
+from app.group.serializers import (
+    FineNoUserSerializer,
+    MembershipHistorySerializer,
+    MembershipSerializer,
+)
+from app.util.mail_creator import MailCreator
+
+
+def export_user_data(request, user):
+    """
+    Finds all data a user is related to, creates a JSON-file for each model with serialized data,
+    zips the files into one zipfile and sends the file to the user's email.
+
+    Must be updated whenever a new model with a relation to User is created.
+
+    Returns a boolean indicating whether the email was successfully sent
+    """
+
+    try:
+        data = {}
+
+        data["bruker"] = UserSerializer(user, context={"request": request}).data
+
+        data["aktivitet"] = serializers.serialize(
+            "json", LogEntry.objects.filter(user=user)
+        )
+
+        notifications = NotificationSerializer(
+            # Todo: refactor to use `user.notifications`
+            Notification.objects.filter(user=user),
+            many=True,
+            context={"request": request},
+        )
+        data["varsler"] = notifications.data
+
+        registrations = RegistrationSerializer(
+            user.registrations, many=True, context={"request": request}
+        )
+        data["paameldinger"] = registrations.data
+
+        memberships = MembershipSerializer(
+            user.memberships, many=True, context={"request": request}
+        )
+        data["medlemskap"] = memberships.data
+
+        membership_histories = MembershipHistorySerializer(
+            user.membership_histories, many=True, context={"request": request}
+        )
+        data["tidligere_medlemskap"] = membership_histories.data
+
+        short_links = ShortLinkSerializer(
+            user.short_links, many=True, context={"request": request}
+        )
+        data["korte_linker"] = short_links.data
+
+        user_badges = UserBadgeSerializer(
+            user.user_badges, many=True, context={"request": request}
+        )
+        data["badges"] = user_badges.data
+
+        strikes = StrikeSerializer(
+            user.strikes, many=True, context={"request": request}
+        )
+        data["prikker"] = strikes.data
+
+        fines = FineNoUserSerializer(
+            user.fines, many=True, context={"request": request}
+        )
+        data["boter"] = fines.data
+
+        submissions = SubmissionGDPRSerializer(
+            user.submissions, many=True, context={"request": request}
+        )
+        data["skjema_svar"] = submissions.data
+
+        is_success = False
+
+        with tempfile.NamedTemporaryFile() as tmp:
+            with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as archive:
+                for model, json in data.items():
+                    archive.writestr(f"{model}.json", JSONRenderer().render(json))
+
+            # Reset file pointer
+            tmp.seek(0)
+
+            is_success = send_html_email(
+                ["olafrosendahl@gmail.com"],
+                MailCreator("Din data")
+                .add_paragraph("Her er din data")
+                .generate_string(),
+                "Din data",
+                [("data.zip", tmp.read(), "application/x-zip-compressed",)],
+            )
+
+        return is_success
+    except Exception as e:
+        capture_exception(e)
+        return False

--- a/app/util/export_user_data.py
+++ b/app/util/export_user_data.py
@@ -2,7 +2,6 @@ import tempfile
 import zipfile
 
 from django.contrib.admin.models import LogEntry
-from django.core import serializers
 from rest_framework.renderers import JSONRenderer
 
 from sentry_sdk import capture_exception
@@ -41,9 +40,7 @@ def export_user_data(request, user):
 
         data["bruker"] = UserSerializer(user, context={"request": request}).data
 
-        data["aktivitet"] = serializers.serialize(
-            "json", LogEntry.objects.filter(user=user)
-        )
+        data["aktivitet"] = LogEntry.objects.filter(user=user).values()
 
         notifications = NotificationSerializer(
             # Todo: refactor to use `user.notifications`
@@ -104,7 +101,7 @@ def export_user_data(request, user):
             tmp.seek(0)
 
             is_success = send_html_email(
-                ["olafrosendahl@gmail.com"],
+                [user.email],
                 MailCreator("Din data")
                 .add_paragraph("Her er din data")
                 .generate_string(),

--- a/app/util/export_user_data.py
+++ b/app/util/export_user_data.py
@@ -102,10 +102,18 @@ def export_user_data(request, user):
 
             is_success = send_html_email(
                 [user.email],
-                MailCreator("Din data")
-                .add_paragraph("Her er din data")
+                MailCreator("Dataeksport")
+                .add_paragraph(
+                    "Vi har samlet alle dataene som er knyttet til din bruker på TIHLDE.org og samlet dem i den vedlagte zip-filen. Dataene ligger kategorisert i hver sin JSON-fil."
+                )
+                .add_paragraph(
+                    "Om noe av innholdet er uklart eller du ønsker med informasjon kan du ta kontakt med Index, kontaktinfo finner du på nettsiden."
+                )
+                .add_paragraph(
+                    "Hvis du ønsker å slette din profil og alle dine brukerdata så kan du gjøre det i profilen din på nettsiden."
+                )
                 .generate_string(),
-                "Din data",
+                "Dataeksport",
                 [("data.zip", tmp.read(), "application/x-zip-compressed",)],
             )
 


### PR DESCRIPTION
## Proposed changes
Brukere kan få tilsendt egne brukerdata på epost ved å sende en GET-request til `users/me/data/`. Dataen kommer som en zip-fil med en json-fil per modell der bruker-relasjon finnes.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/31009729/151452943-579a60ae-178c-4257-9660-ce6295388858.png">


Issue number: closes #397 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The fixtures have been updated if needed (for migrations)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Format and lint (`make format` and `make flake8`) was run locally without failures