### PR TITLE
fix(forms): added resource_type and viewer_has_answered to formserializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 
 ## Neste versjon
+- ⚡ **Spørreskjemaer**. Liste med maler av spørreskjemaer viser nå type spørreskjema og om bruker har svart.
 - ✨ **GDPR**. Muliggjort eksportering av alle brukers data. Blir sendt som zip-fil til brukers mail på forepørsel.
 - ⚡ **Arrangement**. Mulighet til å se om et arrangement er lukket fra en liste med arrangementer
 

--- a/app/forms/serializers/__init__.py
+++ b/app/forms/serializers/__init__.py
@@ -3,7 +3,6 @@ from app.forms.serializers.forms import (
     FormInSubmissionSerializer,
     FormPolymorphicSerializer,
     FormSerializer,
-    AnswerableFormSerializer,
     EventFormSerializer,
     OptionSerializer,
 )

--- a/app/forms/serializers/forms.py
+++ b/app/forms/serializers/forms.py
@@ -187,4 +187,4 @@ class FormPolymorphicSerializer(PolymorphicSerializer, serializers.ModelSerializ
 
     class Meta:
         model = Form
-        fields = ("resource_type",) + FormSerializer.Meta.fields
+        fields = FormSerializer.Meta.fields

--- a/app/forms/views/form.py
+++ b/app/forms/views/form.py
@@ -5,8 +5,10 @@ from rest_framework.response import Response
 from app.common.permissions import BasicViewPermission
 from app.forms.mixins import APIFormErrorsMixin
 from app.forms.models import Form
-from app.forms.serializers import FormPolymorphicSerializer
-from app.forms.serializers.forms import FormSerializer
+from app.forms.serializers.forms import (
+    FormPolymorphicSerializer,
+    FormSerializer,
+)
 from app.forms.serializers.statistics import FormStatisticsSerializer
 
 

--- a/app/tests/forms/test_form_integration.py
+++ b/app/tests/forms/test_form_integration.py
@@ -104,6 +104,8 @@ def test_list_form_templates_data(admin_user):
             }
         ],
         "template": True,
+        "resource_type": form._meta.object_name,
+        "viewer_has_answered": False,
     }
 
 


### PR DESCRIPTION
## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

Merged together FormSerializer and AnswerableFormSerializer as the only difference between these two is the field `viewer_has_answered`. In addition, I added the field `resource_type` to  FormSerializer. With this, listing all form templates will display `resource_type `and `viewer_has_answered`. This is needed for TIHLDE/Kvark#323.

Issue number: closes #403 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Format and lint (`make format` and `make flake8`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
