### PR TITLE
fix(users): permission write check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+- 🦟 **Brukere**. Brukere som ikke er admin får ikke lenger se brukeradmin på nettsiden. De hadde aldri tilgang til å endre dem.
+
 ## Versjon 2022.02.06
 - ⚡ **Registreringer**. La til filtrering på registreringer til arrangementer.
 

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -68,7 +68,7 @@ GENDER = (
 
 
 class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
-    write_access = [AdminGroup.HS, AdminGroup.INDEX]
+    write_access = AdminGroup.admin()
     read_access = [Groups.TIHLDE]
 
     user_id = models.CharField(max_length=15, primary_key=True)
@@ -168,7 +168,12 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
 
     @classmethod
     def has_write_permission(cls, request):
-        return bool(request.user)
+        user_id = request.parser_context.get("kwargs", {}).get("pk", None)
+        if user_id == "me":
+            return bool(request.user)
+        if user_id:
+            return request.user.user_id == user_id or check_has_access(cls.write_access, request,)
+        return check_has_access(cls.write_access, request,)
 
     @classmethod
     def has_create_permission(cls, request):

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -172,7 +172,9 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
         if user_id == "me":
             return bool(request.user)
         if user_id:
-            return request.user.user_id == user_id or check_has_access(cls.write_access, request,)
+            return request.user.user_id == user_id or check_has_access(
+                cls.write_access, request,
+            )
         return check_has_access(cls.write_access, request,)
 
     @classmethod

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -168,6 +168,8 @@ class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
 
     @classmethod
     def has_write_permission(cls, request):
+        if not request.user:
+            return False
         user_id = request.parser_context.get("kwargs", {}).get("pk", None)
         if user_id == "me":
             return bool(request.user)

--- a/app/content/views/accept_form.py
+++ b/app/content/views/accept_form.py
@@ -33,7 +33,7 @@ def accept_form(request):
                 f"Kontaktperson: {body['info']['kontaktperson']}, epost: {body['info']['epost']}"
             )
             .add_paragraph(f"Valgt semester: {', '.join(times)}")
-            .add_paragraph(f"Valgt arrangement: {', '.join()}")
+            .add_paragraph(f"Valgt arrangement: {', '.join(types)}")
             .add_paragraph(f"Kommentar: {body['comment']}")
             .generate_string(),
             subject=title,

--- a/app/static/templates/base.html
+++ b/app/static/templates/base.html
@@ -71,7 +71,7 @@
             <p><a style="color:white;text-decoration:underline;" href="mailto:hs@tihlde.org">Kontakt oss</a> | <a style="color:white;text-decoration: underline;" href="https://tihlde.org">tihlde.org</a></p>
         </div>
         <div style="padding: 0 20px;">
-            <p style="font-size:0.80rem;color:white;padding-top:20px;">Sendt med 💗 av <a style="font-size:0.80rem;color:white;text-decoration: underline;" href="https://tihlde.org/om/tihlde/undergrupper/index/">TIHLDE Index</a></p>
+            <p style="font-size:0.80rem;color:white;padding-top:20px;">Sendt med 💗 av <a style="font-size:0.80rem;color:white;text-decoration: underline;" href="https://tihlde.org/wiki/tihlde/undergrupper/index/">TIHLDE Index</a></p>
         </div>
     </div>
 </center>


### PR DESCRIPTION
## Proposed changes
Fikser en feil som førte til at alle brukere fikk `users: { write: true }` i permissions selv om de kun kunne endre egen bruker. Nå får kun Index og HS-medlemmer `write: true`. Fikset også en liten bug i accept-form og oppdatert url til index i mails.

Issue number: closes N/A


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The fixtures have been updated if needed (for migrations)
- [x] Pull request title follows [conventional commits](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) (`type(scope): description`)
- [x] Format and lint (`make format` and `make flake8`) was run locally without failures


## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
