### PR TITLE
fix(exceptions): image and badge exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 ---
 
 ## Neste versjon
+- 🦟 **Bilder**. Fikset feil som oppstod ved opplastning av profilbilde.
+- 🦟 **Badges**. Håndterer input av ugyldig badge.
+- ⚡ **Galleri**. Sender en respons ved sletting av galleri og bilder i galleri.
+
 ## Versjon 2022.03.04
 - 🦟 **Badge**. Fikset en bug som forårsaket at badges ble kvadrert under kategorier.
 - ✨ **Nyheter**. Forfatteren av nyheter blir offentliggjort.

--- a/app/common/azure_file_handler.py
+++ b/app/common/azure_file_handler.py
@@ -29,8 +29,11 @@ class AzureFileHandler(FileHandler):
         return container
 
     def getContainerAndNameFromUrl(self):
+        import urllib.parse
+
+        url = urllib.parse.unquote(self.url)
         # fmt: off
-        return re.sub("\w+:\/{2}[\d\w-]+(\.[\d\w-]+)*/", "", self.url).split("/")  # noqa: W605
+        return re.sub("\w+:\/{2}[\d\w-]+(\.[\d\w-]+)*/", "", url).split("/")  # noqa: W605
         # fmt: on
 
     def uploadBlob(self):

--- a/app/common/file_handler.py
+++ b/app/common/file_handler.py
@@ -32,12 +32,16 @@ class FileHandler(ABC):
         pass
 
 
-def replace_file(instance, validated_data):
+def replace_file(instance_image, validated_data_image):
     from django.conf import settings
+
+    from sentry_sdk import capture_exception
 
     from app.common.azure_file_handler import AzureFileHandler
 
-    assert hasattr(instance, "image") and "image" in validated_data
-    if instance.image != validated_data["image"] and not settings.DEBUG:
-        if settings.AZURE_BLOB_STORAGE_NAME in instance.image:
-            AzureFileHandler(url=instance.image).deleteBlob()
+    if instance_image and instance_image != validated_data_image:
+        if settings.AZURE_BLOB_STORAGE_NAME in instance_image:
+            try:
+                AzureFileHandler(url=instance_image).deleteBlob()
+            except Exception as e:
+                capture_exception(e)

--- a/app/common/serializers.py
+++ b/app/common/serializers.py
@@ -5,6 +5,6 @@ from app.common.file_handler import replace_file
 
 class BaseModelSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
-        if hasattr(instance, "image") and "image" in validated_data:
-            replace_file(instance, validated_data)
+        if hasattr(instance, "image"):
+            replace_file(instance.image, validated_data.get("image", None))
         return super().update(instance, validated_data)

--- a/app/content/views/user.py
+++ b/app/content/views/user.py
@@ -151,9 +151,18 @@ class UserViewSet(BaseViewSet, ActionMixin):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def post_user_badges(self, request, *args, **kwargs):
+        import uuid
 
         user = self.request.user
-        badge = get_object_or_404(Badge, flag=request.data.get("flag"))
+        try:
+            flag = uuid.UUID(request.data.get("flag"))
+        except ValueError:
+            return Response(
+                {"detail": "Ugyldig flagg"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        badge = get_object_or_404(Badge, flag=flag)
 
         if not badge.is_active:
             return Response(

--- a/app/content/views/user.py
+++ b/app/content/views/user.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db import IntegrityError
 from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, status
@@ -174,8 +175,16 @@ class UserViewSet(BaseViewSet, ActionMixin):
             user_badge, data=request.data, context={"request": request}
         )
         if serializer.is_valid():
-            super().perform_create(serializer)
-            return Response({"detail": "Badge fullført!"}, status=status.HTTP_200_OK)
+            try:
+                super().perform_create(serializer)
+                return Response(
+                    {"detail": "Badge fullført!"}, status=status.HTTP_200_OK
+                )
+            except IntegrityError:
+                return Response(
+                    {"detail": "Du har allerede mottatt denne badgen"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
         else:
             return Response(
                 {"detail": "Badgen kunne ikke bli opprettet"},

--- a/app/gallery/views/album.py
+++ b/app/gallery/views/album.py
@@ -1,5 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters
+from rest_framework import filters, status
+from rest_framework.response import Response
 
 from app.common.pagination import BasePagination
 from app.common.permissions import BasicViewPermission
@@ -18,3 +19,7 @@ class AlbumViewSet(BaseViewSet):
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
     filterset_class = AlbumFilter
     search_fields = ["title", "description"]
+
+    def destroy(self, request, *args, **kwargs):
+        super().destroy(request, *args, **kwargs)
+        return Response({"detail": "Galleriet ble slettet"}, status=status.HTTP_200_OK)

--- a/app/gallery/views/picture.py
+++ b/app/gallery/views/picture.py
@@ -57,3 +57,9 @@ class PictureViewSet(BaseViewSet):
             },
             status=status.HTTP_400_BAD_REQUEST,
         )
+
+    def destroy(self, request, *args, **kwargs):
+        super().destroy(request, *args, **kwargs)
+        return Response(
+            {"detail": "Bildet ble fjernet fra galleriet"}, status=status.HTTP_200_OK
+        )


### PR DESCRIPTION
## Proposed changes

- Fikset feil som oppstod ved opplastning av profilbilde.
  - Her var det 2 forskjellige typer feil:
    - Hvis eksisterende bilde hadde space i url, så var det ikke mulig å finne bildet i Azure uten å urldecode
    - Hvis eksisterende instans var null i databasen, så ga `settings.AZURE_BLOB_STORAGE_NAME in instance.image` feilen i #435 
- Håndterer input av ugyldig badge samt forsøk på å få samme badge flere ganger
- Sender en respons ved sletting av galleri og bilder i galleri.

Issue number: closes #486 closes #435 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The fixtures have been updated if needed (for migrations)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
