### PR TITLE
refactor(rabbitmq): run in docker-compose

### DIFF
--- a/.envs/.local
+++ b/.envs/.local
@@ -5,4 +5,3 @@ DATABASE_NAME=nettside-dev
 DATABASE_PASSWORD=password
 DATABASE_PORT=3306
 DATABASE_USER=root
-CELERY_URL=memory://localhost/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ---
 
 ## Neste versjon
+- ⚡ **RabbitMQ**. Kjører nå RabbitMQ i Docker-Compose istedenfor i en egen instans.
 - ✨ **Arrangementer**. Varsel om at påmelding har åpnet sendes nå i Slack.
 - ✨ **Arrangementsprioriteringer** kan nå lages med grupper og ikke kun for klasser.
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,6 @@ EMAIL_PORT= PORT (normally 587)
 EMAIL_USER= EMAIL_USER
 EMAIL_PASSWORD= EMAIL_PASSWORD
 
-# Optional for connecting to celery broker
-CELERY_URL= CELERY_BROKER_URL
-
 # Optional for uploading files to Azure
 AZURE_STORAGE_CONNECTION_STRING= CONNECTION_STRING
 ```

--- a/app/settings.py
+++ b/app/settings.py
@@ -272,6 +272,6 @@ LOGGING = {
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
-CELERY_BROKER_URL = os.environ.get("CELERY_URL")
+CELERY_BROKER_URL = "amqp://guest:guest@rabbitmq:5672"
 if ENVIRONMENT == EnvironmentOptions.LOCAL:
     CELERY_TASK_ALWAYS_EAGER = True

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,3 @@ services:
     container_name: rabbitmq
     ports:
         - 5672:5672
-    volumes:
-        - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
-        - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,3 +13,11 @@ services:
     container_name: celery
     entrypoint: []
     command: celery --app app worker --task-events --beat --loglevel info
+  rabbitmq:
+    image: rabbitmq:3.9.13
+    container_name: rabbitmq
+    ports:
+        - 5672:5672
+    volumes:
+        - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
+        - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,3 @@ services:
     container_name: rabbitmq
     ports:
         - 5672:5672
-    volumes:
-        - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
-        - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,3 +13,11 @@ services:
     container_name: celery
     entrypoint: []
     command: celery --app app worker --task-events --beat --loglevel info
+  rabbitmq:
+    image: rabbitmq:3.9.13
+    container_name: rabbitmq
+    ports:
+        - 5672:5672
+    volumes:
+        - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
+        - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,12 @@ services:
     entrypoint: []
     command: celery --app app worker --task-events --beat --loglevel info
     ports: []
+
+  rabbitmq:
+    image: rabbitmq:3.9.13
+    container_name: rabbitmq
+    ports:
+        - 5672:5672
+    volumes:
+        - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
+        - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,3 @@ services:
     container_name: rabbitmq
     ports:
         - 5672:5672
-    volumes:
-        - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
-        - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq


### PR DESCRIPTION
## Proposed changes

Issue number: closes #477 

Kjører RabbitMQ i Docker-Compose istedenfor å ha en egen instans i Azure Container Instances ettersom ingen viktig data lagres der.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The fixtures have been updated if needed (for migrations)