### PR TITLE
fix(notification): Avoid Slack as only channel when not connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+- 🦟 **Varslinger**. Brukere kan ikke lenger sette Slack som eneste kommunikasjonskanal uten å koble til Slack-konto.
+
 ## Versjon 2022.05.12
 - ✨ **Varsler**. Ny medlemmer og ledere av grupper får nå mer informasjon om hva det innebærer.
 

--- a/app/communication/models/user_notification_setting.py
+++ b/app/communication/models/user_notification_setting.py
@@ -30,7 +30,7 @@ class UserNotificationSetting(BaseModel):
         )
 
     def clean(self):
-        if not self.email and not self.website and not self.slack:
+        if not self.email and not self.website and not (self.slack and self.user.slack_user_id):
             raise AllChannelsUnselected("Du må velge minst en kommunikasjonsmetode")
 
     @classmethod


### PR DESCRIPTION
## Proposed changes
Added an extra check to make sure the Slack account is connected if it is to be used as the only notification channel.
You may not disable the two other channels if Slack is not connected.

Issue number: closes #538 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
