### PR TITLE
fix: remove blob deletion on image change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ---
 
 ## Neste versjon
+- 🦟 **Bilder**. Bilder slettes ikke lengre fra fillagring.
+
 ## Versjon 2022.10.13
 - 🦟 **Galleri**. Problem hvor galleri ble duplisert er fikset.
 - 🦟 **Notifikasjoner** Fikset noen grammatiske feil i notifikasjonene.

--- a/app/common/file_handler.py
+++ b/app/common/file_handler.py
@@ -31,18 +31,3 @@ class FileHandler(ABC):
     @abstractmethod
     def uploadBlob(self):
         pass
-
-
-def replace_file(instance_image, validated_data_image):
-    from django.conf import settings
-
-    from sentry_sdk import capture_exception
-
-    from app.common.azure_file_handler import AzureFileHandler
-
-    if instance_image and instance_image != validated_data_image:
-        if settings.AZURE_BLOB_STORAGE_NAME in instance_image:
-            try:
-                AzureFileHandler(url=instance_image).deleteBlob()
-            except Exception as e:
-                capture_exception(e)

--- a/app/common/serializers.py
+++ b/app/common/serializers.py
@@ -1,10 +1,5 @@
 from rest_framework import serializers
 
-from app.common.file_handler import replace_file
-
 
 class BaseModelSerializer(serializers.ModelSerializer):
-    def update(self, instance, validated_data):
-        if hasattr(instance, "image"):
-            replace_file(instance.image, validated_data.get("image", None))
-        return super().update(instance, validated_data)
+    pass


### PR DESCRIPTION
## Proposed changes
I TIHLDE Pythons opplever vi at bilder vi legger til i bøter ofte forsvinner. Det viser seg at de er slettet fra Azure Blob Storage. Fjerner dermed det eneste stedet i koden der blobs blir slettet, så kan dere heller eventuelt finne en bedre løsning for sletting av blobs senere om dere fremdeles mener at det bør skje.

Issue number: closes N/A


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The fixtures have been updated if needed (for migrations)