### PR TITLE
HS can't change users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## Neste versjon
 
+- ⚡ **Bruker** Nå kan ikke HS lenger endre eller slette brukere. 
 - ⚡ **Mails** Nå logger vi på eposttjeneren kun en gang per batch med epost som sendes.
 
 ## Versjon 2022.10.13

--- a/app/content/models/user.py
+++ b/app/content/models/user.py
@@ -56,7 +56,7 @@ GENDER = (
 
 
 class User(AbstractBaseUser, PermissionsMixin, BaseModel, OptionalImage):
-    write_access = AdminGroup.admin()
+    write_access = [AdminGroup.INDEX]
     read_access = [Groups.TIHLDE]
 
     user_id = models.CharField(max_length=15, primary_key=True)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -74,20 +74,6 @@ def admin_user(member):
 
 
 @pytest.fixture()
-def index_user():
-    user = UserFactory()
-    add_user_to_group_with_name(user, AdminGroup.INDEX)
-    return user
-
-
-@pytest.fixture()
-def hs_user():
-    user = UserFactory()
-    add_user_to_group_with_name(user, AdminGroup.HS)
-    return user
-
-
-@pytest.fixture()
 def member():
     user = UserFactory()
     add_user_to_group_with_name(user, Groups.TIHLDE)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -74,6 +74,20 @@ def admin_user(member):
 
 
 @pytest.fixture()
+def index_user():
+    user = UserFactory()
+    add_user_to_group_with_name(user, AdminGroup.INDEX)
+    return user
+
+
+@pytest.fixture()
+def hs_user():
+    user = UserFactory()
+    add_user_to_group_with_name(user, AdminGroup.HS)
+    return user
+
+
+@pytest.fixture()
 def member():
     user = UserFactory()
     add_user_to_group_with_name(user, Groups.TIHLDE)

--- a/app/tests/content/test_user_integration.py
+++ b/app/tests/content/test_user_integration.py
@@ -1,5 +1,4 @@
 from django.utils.text import slugify
-from app.util.test_utils import add_user_to_group_with_name
 from rest_framework import status
 
 import pytest
@@ -12,6 +11,7 @@ from app.content.models import User
 from app.forms.enums import EventFormType
 from app.forms.tests.form_factories import EventFormFactory, SubmissionFactory
 from app.group.models import Group
+from app.util.test_utils import add_user_to_group_with_name
 
 pytestmark = pytest.mark.django_db
 

--- a/app/tests/content/test_user_integration.py
+++ b/app/tests/content/test_user_integration.py
@@ -1,9 +1,10 @@
 from django.utils.text import slugify
+from app.util.test_utils import add_user_to_group_with_name
 from rest_framework import status
 
 import pytest
 
-from app.common.enums import GroupType
+from app.common.enums import AdminGroup, GroupType
 from app.content.factories.registration_factory import RegistrationFactory
 from app.content.factories.strike_factory import StrikeFactory
 from app.content.factories.user_factory import UserFactory
@@ -332,9 +333,10 @@ def test_update_other_user_as_member(member, user, api_client):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_update_other_user_as_hs_user(hs_user, user, api_client):
+def test_update_other_user_as_hs_user(member, user, api_client):
     """A HS member should not be able to update other users."""
-    client = api_client(user=hs_user)
+    add_user_to_group_with_name(member, AdminGroup.HS)
+    client = api_client(user=member)
     data = _get_user_put_data()
     url = _get_user_detail_url(user)
     response = client.put(url, data)
@@ -342,12 +344,13 @@ def test_update_other_user_as_hs_user(hs_user, user, api_client):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_update_other_user_as_index_user(index_user, user, api_client):
+def test_update_other_user_as_index_user(member, user, api_client):
     """
     Members of Index should be able to update other users.
     Index should be able to update all fields.
     """
-    client = api_client(user=index_user)
+    add_user_to_group_with_name(member, AdminGroup.INDEX)
+    client = api_client(user=member)
     data = _get_user_put_data()
     url = _get_user_detail_url(user)
     response = client.put(url, data)
@@ -449,18 +452,20 @@ def test_destroy_other_user_as_member(member, user, api_client):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_destroy_other_user_as_hs_user(hs_user, user, api_client):
+def test_destroy_other_user_as_hs_user(member, user, api_client):
     """A HS user should not be able to destroy other users."""
-    client = api_client(user=hs_user)
+    add_user_to_group_with_name(member, AdminGroup.HS)
+    client = api_client(user=member)
     url = _get_user_detail_url(user)
     response = client.delete(url)
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_destroy_other_user_as_index_user(index_user, user, api_client):
+def test_destroy_other_user_as_index_user(member, user, api_client):
     """An index user should be able to destroy other users."""
-    client = api_client(user=index_user)
+    add_user_to_group_with_name(member, AdminGroup.INDEX)
+    client = api_client(user=member)
     url = _get_user_detail_url(user)
     response = client.delete(url)
 

--- a/app/tests/content/test_user_integration.py
+++ b/app/tests/content/test_user_integration.py
@@ -331,13 +331,21 @@ def test_update_other_user_as_member(member, user, api_client):
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
+def test_update_other_user_as_hs_user(hs_user, user, api_client):
+    """A HS member should not be able to update other users."""
+    client = api_client(user=hs_user)
+    data = _get_user_put_data()
+    url = _get_user_detail_url(user)
+    response = client.put(url, data)
 
-def test_update_other_user_as_admin_user(admin_user, user, api_client):
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+def test_update_other_user_as_index_user(index_user, user, api_client):
     """
-    A admin user should be able to update other users.
-    Admins should be able to update all fields.
+    Members of Index should be able to update other users.
+    Index should be able to update all fields.
     """
-    client = api_client(user=admin_user)
+    client = api_client(user=index_user)
     data = _get_user_put_data()
     url = _get_user_detail_url(user)
     response = client.put(url, data)
@@ -438,10 +446,17 @@ def test_destroy_other_user_as_member(member, user, api_client):
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
+def test_destroy_other_user_as_hs_user(hs_user, user, api_client):
+    """A HS user should not be able to destroy other users."""
+    client = api_client(user=hs_user)
+    url = _get_user_detail_url(user)
+    response = client.delete(url)
 
-def test_destroy_other_user_as_admin_user(admin_user, user, api_client):
-    """An admin user should be able to destroy other users."""
-    client = api_client(user=admin_user)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+def test_destroy_other_user_as_index_user(index_user, user, api_client):
+    """An index user should be able to destroy other users."""
+    client = api_client(user=index_user)
     url = _get_user_detail_url(user)
     response = client.delete(url)
 

--- a/app/tests/content/test_user_integration.py
+++ b/app/tests/content/test_user_integration.py
@@ -331,6 +331,7 @@ def test_update_other_user_as_member(member, user, api_client):
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
+
 def test_update_other_user_as_hs_user(hs_user, user, api_client):
     """A HS member should not be able to update other users."""
     client = api_client(user=hs_user)
@@ -339,6 +340,7 @@ def test_update_other_user_as_hs_user(hs_user, user, api_client):
     response = client.put(url, data)
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
 
 def test_update_other_user_as_index_user(index_user, user, api_client):
     """
@@ -446,6 +448,7 @@ def test_destroy_other_user_as_member(member, user, api_client):
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
+
 def test_destroy_other_user_as_hs_user(hs_user, user, api_client):
     """A HS user should not be able to destroy other users."""
     client = api_client(user=hs_user)
@@ -453,6 +456,7 @@ def test_destroy_other_user_as_hs_user(hs_user, user, api_client):
     response = client.delete(url)
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
 
 def test_destroy_other_user_as_index_user(index_user, user, api_client):
     """An index user should be able to destroy other users."""


### PR DESCRIPTION
## Proposed changes
HS have decided that HS members no longer can change or delete users. Changed their permissions.

Issue number: closes #651 


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)
