### PR TITLE
Feat(event)/waitlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - 🦟 **Bøter** Nå skal bilder på bøter ikke lengre forsvinne.
 - ✨ **Betalte arrangementer med Vipps betaling**. Det kan nå opprettes arrangementer som krever betaling for å melde seg på. Denne betalingen betales via Vipps.
 - ⚡ **Nyheter** Fondesforvalere kan nå lage nyheter.
+- ⚡ **Arrangementer** Du kan nå se hvilken plass du har på ventelisten til et arrangement.
 
 ## Versjon 2022.10.13
 

--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -214,11 +214,12 @@ class Registration(BaseModel, BasePermissionModel):
         """
         Returns the number of people in front of the user in the waiting list.
         """
-        return (self.event.get_waiting_list().order_by("-created_at")
-                .filter(
-            is_on_wait=True,
-            created_at__lt=self.created_at
-        ).count()) + 1
+        return (
+            self.event.get_waiting_list()
+            .order_by("-created_at")
+            .filter(is_on_wait=True, created_at__lt=self.created_at)
+            .count()
+        ) + 1
 
     def swap_users(self):
         """Swaps a user with a spot with a prioritized user, if such user exists"""

--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -209,6 +209,17 @@ class Registration(BaseModel, BasePermissionModel):
 
         return False
 
+    @property
+    def wait_queue_number(self):
+        """
+        Returns the number of people in front of the user in the waiting list.
+        """
+        return (self.event.get_waiting_list().order_by("-created_at")
+                .filter(
+            is_on_wait=True,
+            created_at__lt=self.created_at
+        ).count()) + 1
+
     def swap_users(self):
         """Swaps a user with a spot with a prioritized user, if such user exists"""
         for registration in self.event.get_participants().order_by("-created_at"):

--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -214,12 +214,17 @@ class Registration(BaseModel, BasePermissionModel):
         """
         Returns the number of people in front of the user in the waiting list.
         """
-        return (
+        waiting_list_count = (
             self.event.get_waiting_list()
             .order_by("-created_at")
-            .filter(is_on_wait=True, created_at__lt=self.created_at)
+            .filter(created_at__lte=self.created_at)
             .count()
-        ) + 1
+        )
+
+        if waiting_list_count == 0 or not self.is_on_wait:
+            return None
+
+        return waiting_list_count
 
     def swap_users(self):
         """Swaps a user with a spot with a prioritized user, if such user exists"""

--- a/app/content/serializers/registration.py
+++ b/app/content/serializers/registration.py
@@ -18,6 +18,7 @@ class RegistrationSerializer(BaseModelSerializer):
     has_unanswered_evaluation = serializers.SerializerMethodField()
     order = serializers.SerializerMethodField(required=False)
     has_paid_order = serializers.SerializerMethodField(required=False)
+    wait_queue_number = serializers.SerializerMethodField(required=False)
 
     class Meta:
         model = Registration
@@ -32,6 +33,7 @@ class RegistrationSerializer(BaseModelSerializer):
             "has_unanswered_evaluation",
             "order",
             "has_paid_order",
+            "wait_queue_number",
         )
 
     def get_survey_submission(self, obj):
@@ -55,6 +57,11 @@ class RegistrationSerializer(BaseModelSerializer):
                 or order.status == OrderStatus.SALE
             ):
                 return True
+
+    def get_wait_queue_number(self, obj):
+        if obj.is_on_wait:
+            return obj.wait_queue_number
+        return None
 
 
 class PublicRegistrationSerializer(BaseModelSerializer):

--- a/app/content/tests/test_registration_model.py
+++ b/app/content/tests/test_registration_model.py
@@ -537,8 +537,9 @@ def test_strikes_has_no_effect_if_event_has_strikes_disabled(
     is_prioritized = not enable_strikes
     assert registration.is_prioritized == is_prioritized
 
+
 def test_wait_queue_number_is_null_when_not_in_wait_list(
-        user_not_in_priority_pool, event_with_priority_pool
+    user_not_in_priority_pool, event_with_priority_pool
 ):
     registration_not_in_priority_pool = RegistrationFactory(
         event=event_with_priority_pool, user=user_not_in_priority_pool
@@ -546,8 +547,9 @@ def test_wait_queue_number_is_null_when_not_in_wait_list(
 
     assert registration_not_in_priority_pool.wait_queue_number is None
 
+
 def test_wait_queue_number_is_correct_when_in_wait_list(
-        user_not_in_priority_pool, event_with_priority_pool
+    user_not_in_priority_pool, event_with_priority_pool
 ):
     registration_not_in_priority_pool = RegistrationFactory(
         event=event_with_priority_pool, user=user_not_in_priority_pool

--- a/app/content/tests/test_registration_model.py
+++ b/app/content/tests/test_registration_model.py
@@ -536,3 +536,27 @@ def test_strikes_has_no_effect_if_event_has_strikes_disabled(
     )
     is_prioritized = not enable_strikes
     assert registration.is_prioritized == is_prioritized
+
+def test_wait_queue_number_is_null_when_not_in_wait_list(
+        user_not_in_priority_pool, event_with_priority_pool
+):
+    registration_not_in_priority_pool = RegistrationFactory(
+        event=event_with_priority_pool, user=user_not_in_priority_pool
+    )
+
+    assert registration_not_in_priority_pool.wait_queue_number is None
+
+def test_wait_queue_number_is_correct_when_in_wait_list(
+        user_not_in_priority_pool, event_with_priority_pool
+):
+    registration_not_in_priority_pool = RegistrationFactory(
+        event=event_with_priority_pool, user=user_not_in_priority_pool
+    )
+    other_user_not_in_priority_pool = UserFactory()
+    other_registration_not_in_priority_pool = RegistrationFactory(
+        event=event_with_priority_pool, user=other_user_not_in_priority_pool
+    )
+
+    assert not registration_not_in_priority_pool.is_on_wait
+    assert registration_not_in_priority_pool.wait_queue_number is None
+    assert other_registration_not_in_priority_pool.is_on_wait == 1

--- a/app/content/tests/test_registration_model.py
+++ b/app/content/tests/test_registration_model.py
@@ -561,4 +561,27 @@ def test_wait_queue_number_is_correct_when_in_wait_list(
 
     assert not registration_not_in_priority_pool.is_on_wait
     assert registration_not_in_priority_pool.wait_queue_number is None
-    assert other_registration_not_in_priority_pool.is_on_wait == 1
+    assert other_registration_not_in_priority_pool.wait_queue_number == 1
+
+
+def test_wait_queue_number_is_correct_when_not_first_in_wait_list(
+    user_not_in_priority_pool, event_with_priority_pool
+):
+    registration_not_in_priority_pool = RegistrationFactory(
+        event=event_with_priority_pool, user=user_not_in_priority_pool
+    )
+
+    second_user_not_in_priority_pool = UserFactory()
+    second_registration_not_in_priority_pool = RegistrationFactory(
+        event=event_with_priority_pool, user=second_user_not_in_priority_pool
+    )
+
+    third_user_not_in_priority_pool = UserFactory()
+    third_registration_not_in_priority_pool = RegistrationFactory(
+        event=event_with_priority_pool, user=third_user_not_in_priority_pool
+    )
+
+    assert not registration_not_in_priority_pool.is_on_wait
+    assert registration_not_in_priority_pool.wait_queue_number is None
+    assert second_registration_not_in_priority_pool.wait_queue_number == 1
+    assert third_registration_not_in_priority_pool.wait_queue_number == 2


### PR DESCRIPTION
## Proposed changes
Added a wait_queue_number field on the RegistrationSerializer so that users can see which place they have in the waitlist.

Issue number: closes #721

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] CHANGELOG.md has been updated. [Guide](https://tihlde.slab.com/posts/changelog-z8hybjom)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] The fixtures have been updated if needed (for migrations)

## Further comments

I chose the solution of finding the count of users in the waitlist that were added before you, in other words, performing an aggregation query for each request. I did this instead of adding a field on the Registration model itself, since that would mean mutating every waitlist registration of the event whenever one person is moved up the queue.
