### PR TITLE
Removed SQL logging settings

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -272,12 +272,13 @@ LOGGING = {
             "formatter": "verbose",
         },
     },
-    "loggers": {
-        "django": {
-            "propagate": True,
-            "level": "DEBUG",
-        },
-    },
+    # REMOVE COMMENTS TO ADD SQL LOGGING
+    # "loggers": {
+    #     "django": {
+    #         "propagate": True,
+    #         "level": "DEBUG",
+    #     },
+    # },
     "root": {
         "handlers": ["file"],
     },


### PR DESCRIPTION
## Proposed changes

While using pytest there are a lot of DEBUG logs when the test has a 500 error. I commented out the logging settings, and added description for getting it back. We don't use the logs, so it is no reason to have it.


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] API docs on [Codex](https://codex.tihlde.org/contributing) have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
