### PR TITLE
fixed bug of payment countdown for registrations from waitlist to queue

### DIFF
--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -132,10 +132,7 @@ class Registration(BaseModel, BasePermissionModel):
         if moved_registration:
             moved_registration.save()
 
-            if (
-                moved_registration.event.is_paid_event
-                and not moved_registration.is_on_wait
-            ):
+            if moved_registration.event.is_paid_event:
                 try:
                     start_payment_countdown(
                         moved_registration.event, moved_registration


### PR DESCRIPTION
## Proposed changes
When an user get upped from the waiting list, the payment_counter that checks if the order is paid, does not start. I have fixed this bug now.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] API docs on [Codex](https://codex.tihlde.org/contributing) have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
