### PR TITLE
Fix(kontres)/return full sober watch

### DIFF
--- a/app/kontres/serializer/reservation_seralizer.py
+++ b/app/kontres/serializer/reservation_seralizer.py
@@ -31,6 +31,11 @@ class ReservationSerializer(serializers.ModelSerializer):
     )
     author_detail = UserSerializer(source="author", read_only=True)
 
+    sober_watch = serializers.PrimaryKeyRelatedField(
+        queryset=User.objects.all(), write_only=True, required=False
+    )
+    sober_watch_detail = UserSerializer(source="sober_watch", read_only=True)
+
     class Meta:
         model = Reservation
         fields = "__all__"

--- a/app/tests/kontres/test_reservation_integration.py
+++ b/app/tests/kontres/test_reservation_integration.py
@@ -37,7 +37,9 @@ def test_member_can_create_reservation(member, bookable_item):
 
 
 @pytest.mark.django_db
-def test_member_can_create_reservation_with_alcohol(member, bookable_item):
+def test_member_can_create_reservation_with_alcohol_and_sober_watch(
+    member, bookable_item
+):
     client = get_api_client(user=member)
 
     bookable_item.allows_alcohol = True
@@ -57,7 +59,7 @@ def test_member_can_create_reservation_with_alcohol(member, bookable_item):
 
     assert response.status_code == 201, response.data
     assert response.data.get("serves_alcohol") is True
-    assert response.data.get("sober_watch") == str(member.user_id)
+    assert response.data["sober_watch_detail"]["user_id"] == str(member.user_id)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Proposed changes

full sober watch user object will now be returned in response. can be accesses via sober_watch_detail from frontend

Issue number: closes # (remove if not an issue)


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] API docs on [Codex](https://codex.tihlde.org/contributing) have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
