### PR TITLE
Memberships with fines activated

### DIFF
--- a/app/content/views/user.py
+++ b/app/content/views/user.py
@@ -181,6 +181,20 @@ class UserViewSet(BaseViewSet, ActionMixin):
             context={"request": request},
         )
 
+    @action(detail=True, methods=["get"], url_path="memberships-with-fines")
+    def get_user_memberships_with_fines(self, request, pk, *args, **kwargs):
+        user = self._get_user(request, pk)
+        self.check_object_permissions(self.request, user)
+
+        memberships = user.memberships.filter(
+            group__type__in=GroupType.public_groups(), group__fines_activated=True
+        ).order_by("-created_at")
+        return self.paginate_response(
+            data=memberships,
+            serializer=MembershipSerializer,
+            context={"request": request},
+        )
+
     @action(detail=True, methods=["get"], url_path="membership-histories")
     def get_user_membership_histories(self, request, pk, *args, **kwargs):
         user = self._get_user(request, pk)

--- a/app/group/serializers/group.py
+++ b/app/group/serializers/group.py
@@ -22,6 +22,7 @@ class SimpleGroupSerializer(BaseModelSerializer):
             "viewer_is_member",
             "image",
             "image_alt",
+            "fines_activated",
         )
 
     def get_viewer_is_member(self, obj):

--- a/app/tests/content/test_user_integration.py
+++ b/app/tests/content/test_user_integration.py
@@ -180,6 +180,7 @@ def test_filter_only_users_with_active_strikes(
     [
         ("/", status.HTTP_200_OK),
         ("/memberships/", status.HTTP_200_OK),
+        ("/memberships-with-fines/", status.HTTP_200_OK),
         ("/membership-histories/", status.HTTP_200_OK),
         ("/badges/", status.HTTP_200_OK),
         ("/events/", status.HTTP_200_OK),


### PR DESCRIPTION
This PR will allow a user to get all memberships for that have fines activated. It is used for the shortcut menu for creating fines faster


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] API docs on [Codex](https://codex.tihlde.org/contributing) have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
