### PR TITLE
Feat(submissions)/deletion of form submission

### DIFF
--- a/app/forms/models/forms.py
+++ b/app/forms/models/forms.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.core.mail import send_mail
 from django.db import models, transaction
 
 from ordered_model.models import OrderedModel
@@ -18,7 +19,6 @@ from app.forms.exceptions import (
 )
 from app.group.models import Group
 from app.util.models import BaseModel
-from django.core.mail import send_mail
 
 
 class Form(PolymorphicModel, BasePermissionModel):
@@ -379,13 +379,12 @@ class Submission(BaseModel, BasePermissionModel):
     def has_download_permission(cls, request):
         return cls.has_list_permission(request)
 
-
     def destroy_submission(self, reason):
         send_mail(
-            subject = "Ditt svar på spørreskjemaet har blitt slettet",
-            message = f"Ditt svar på spørreskjemaet {self.form.title} har blitt slettet av en administrator. Grunnen er: {reason}",
-            from_email = settings.DEFAULT_FROM_EMAIL,
-            recipient_list = [self.user.email],
+            subject="Ditt svar på spørreskjemaet har blitt slettet",
+            message=f"Ditt svar på spørreskjemaet {self.form.title} har blitt slettet av en administrator. Grunnen er: {reason}",
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[self.user.email],
         )
         self.delete()
 

--- a/app/forms/models/forms.py
+++ b/app/forms/models/forms.py
@@ -18,6 +18,7 @@ from app.forms.exceptions import (
 )
 from app.group.models import Group
 from app.util.models import BaseModel
+from django.core.mail import send_mail
 
 
 class Form(PolymorphicModel, BasePermissionModel):

--- a/app/forms/models/forms.py
+++ b/app/forms/models/forms.py
@@ -379,6 +379,16 @@ class Submission(BaseModel, BasePermissionModel):
         return cls.has_list_permission(request)
 
 
+    def destroy_submission(self, reason):
+        send_mail(
+            subject = "Ditt svar på spørreskjemaet har blitt slettet",
+            message = f"Ditt svar på spørreskjemaet {self.form.title} har blitt slettet av en administrator. Grunnen er: {reason}",
+            from_email = settings.DEFAULT_FROM_EMAIL,
+            recipient_list = [self.user.email],
+        )
+        self.delete()
+
+
 class Answer(BaseModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     submission = models.ForeignKey(

--- a/app/forms/models/forms.py
+++ b/app/forms/models/forms.py
@@ -1,6 +1,5 @@
 import uuid
 
-from django.core.mail import send_mail
 from django.db import models, transaction
 
 from ordered_model.models import OrderedModel

--- a/app/forms/models/forms.py
+++ b/app/forms/models/forms.py
@@ -379,15 +379,6 @@ class Submission(BaseModel, BasePermissionModel):
     def has_download_permission(cls, request):
         return cls.has_list_permission(request)
 
-    def destroy_submission(self, reason):
-        send_mail(
-            subject="Ditt svar på spørreskjemaet har blitt slettet",
-            message=f"Ditt svar på spørreskjemaet {self.form.title} har blitt slettet av en administrator. Grunnen er: {reason}",
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            recipient_list=[self.user.email],
-        )
-        self.delete()
-
 
 class Answer(BaseModel):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/app/forms/serializers/submission.py
+++ b/app/forms/serializers/submission.py
@@ -89,3 +89,17 @@ class SubmissionGDPRSerializer(SubmissionInRegistrationSerializer):
     class Meta:
         model = SubmissionInRegistrationSerializer.Meta.model
         fields = SubmissionInRegistrationSerializer.Meta.fields
+
+
+class SubmissionDestroySerializer(serializers.Serializer):
+    reason = serializers.CharField(required=True, allow_blank=False)
+
+    class Meta:
+        fields = ["reason"]
+
+    def validate_reason(self, value):
+        if not value.strip():
+            raise serializers.ValidationError(
+                "Grunnen kan ikke være tom eller kun inneholde mellomrom."
+            )
+        return value

--- a/app/forms/views/submission.py
+++ b/app/forms/views/submission.py
@@ -71,3 +71,11 @@ class SubmissionViewSet(APIFormErrorsMixin, BaseViewSet):
     def download(self, _request, *_args, **_kwargs):
         """To return the response as csv, include header 'Accept: text/csv."""
         return SubmissionsCsvWriter(self.get_queryset()).write_csv()
+
+
+    @action(detail=True, methods=["delete"])
+    def destroy_with_reason(self, request, *args, **kwargs):
+        submission = self.get_object()
+        reason = request.data.get("reason", "No reason provided")
+        submission.destroy(reason)
+        return Response({"detail": "Submission deleted and user notified"}, status=status.HTTP_200_OK)

--- a/app/forms/views/submission.py
+++ b/app/forms/views/submission.py
@@ -72,10 +72,12 @@ class SubmissionViewSet(APIFormErrorsMixin, BaseViewSet):
         """To return the response as csv, include header 'Accept: text/csv."""
         return SubmissionsCsvWriter(self.get_queryset()).write_csv()
 
-
     @action(detail=True, methods=["delete"])
     def destroy_with_reason(self, request, *args, **kwargs):
         submission = self.get_object()
         reason = request.data.get("reason", "No reason provided")
         submission.destroy(reason)
-        return Response({"detail": "Submission deleted and user notified"}, status=status.HTTP_200_OK)
+        return Response(
+            {"detail": "Submission deleted and user notified"},
+            status=status.HTTP_200_OK,
+        )

--- a/app/forms/views/submission.py
+++ b/app/forms/views/submission.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.core.mail import send_mail
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -13,9 +15,11 @@ from app.forms.csv_writer import SubmissionsCsvWriter
 from app.forms.enums import NativeEventFormType as EventFormType
 from app.forms.mixins import APIFormErrorsMixin
 from app.forms.models.forms import EventForm, Form, Submission
-from app.forms.serializers.submission import SubmissionSerializer, SubmissionDestroySerializer
-from django.core.mail import send_mail
-from django.conf import settings
+from app.forms.serializers.submission import (
+    SubmissionDestroySerializer,
+    SubmissionSerializer,
+)
+
 
 class SubmissionViewSet(APIFormErrorsMixin, BaseViewSet):
     serializer_class = SubmissionSerializer

--- a/app/forms/views/submission.py
+++ b/app/forms/views/submission.py
@@ -13,8 +13,9 @@ from app.forms.csv_writer import SubmissionsCsvWriter
 from app.forms.enums import NativeEventFormType as EventFormType
 from app.forms.mixins import APIFormErrorsMixin
 from app.forms.models.forms import EventForm, Form, Submission
-from app.forms.serializers.submission import SubmissionSerializer
-
+from app.forms.serializers.submission import SubmissionSerializer, SubmissionDestroySerializer
+from django.core.mail import send_mail
+from django.conf import settings
 
 class SubmissionViewSet(APIFormErrorsMixin, BaseViewSet):
     serializer_class = SubmissionSerializer


### PR DESCRIPTION
## Proposed changes
Added deletion of a submission including a reason for the deletion. In the serializer I made a SubmissionDestroySerializer that validates the reason for deleting a submission and ensure that it's not empty. In view I made a destroy_with_reason method that allows an administrator to delete a submission and send an email to the user notifying them about the deletion and why it's deleted. The reason for the deleted submission will be passed via the request data and used in the email notification.

Issue number: closes #830 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] API docs on [Codex](https://codex.tihlde.org/contributing) have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)