### PR TITLE
FIX(Email links): Fjerner auto-detect environment.

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -44,15 +44,7 @@ ENVIRONMENT = (
     )
 )
 
-WEBSITE_URL = (
-    "https://tihlde.org"
-    if ENVIRONMENT == EnvironmentOptions.PRODUCTION
-    else (
-        "https://dev.tihlde.org"
-        if ENVIRONMENT == EnvironmentOptions.DEVELOPMENT
-        else "http://localhost:3000"
-    )
-)
+WEBSITE_URL = "https://tihlde.org"
 
 AZURE_BLOB_STORAGE_NAME = "tihldestorage.blob.core.windows.net"
 AZURE_STORAGE_CONNECTION_STRING = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")


### PR DESCRIPTION
Tydeligvis så klarer man ikke å konfigurere miljøet som lepton kjører i riktig. Så jeg sier fuck det nå sender vi alt til __BARE__ https://tihlde.org dersom man tester lokalt, da får man bare bytte ut den linken selv synd for den personen. Denne bugen har vært her lenge og nå sier jeg meg ferdig med den...

Takk for meg.