### PR TITLE
Fix expired unpaid registrations not moved back to waiting list

### DIFF
--- a/app/celery.py
+++ b/app/celery.py
@@ -49,6 +49,11 @@ schedule = {
         # 12:00 every day
         "schedule": crontab(hour="12", minute="0"),
     },
+    "sweep_expired_unpaid_registrations": {
+        "task": "app.payment.tasks.sweep_expired_unpaid_registrations",
+        # Every 5th minute
+        "schedule": crontab(minute="*/5"),
+    },
 }
 
 app.conf.update(

--- a/app/content/models/event.py
+++ b/app/content/models/event.py
@@ -120,10 +120,23 @@ class Event(BaseModel, OptionalImage, BasePermissionModel):
 
     def move_users_from_waiting_list_to_queue(self, count):
         """Moves the first x users from waiting list to queue"""
+        from app.content.util.event_utils import start_payment_countdown
+
+        from sentry_sdk import capture_exception
+
         waiting_list = self.get_waiting_list().order_by("created_at")
         for registration in waiting_list[:count]:
             moved_registration = registration.move_from_waiting_list_to_queue()
-            moved_registration.save()
+            if moved_registration:
+                moved_registration.save()
+                if self.is_paid_event:
+                    try:
+                        start_payment_countdown(
+                            self, moved_registration, from_wait_list=True
+                        )
+                    except Exception as countdown_error:
+                        capture_exception(countdown_error)
+                        moved_registration.delete()
 
     def move_users_from_queue_to_waiting_list(self, count):
         """Moves the last created x users from queue to waiting list"""

--- a/app/content/models/registration.py
+++ b/app/content/models/registration.py
@@ -146,6 +146,8 @@ class Registration(BaseModel, BasePermissionModel):
         return registration
 
     def admin_unregister(self, *args, **kwargs):
+        from app.content.util.event_utils import start_payment_countdown
+
         moved_registration = self.move_from_waiting_list_to_queue()
         self.delete_submission_if_exists()
         self.send_unregistered_notification_and_mail()
@@ -154,6 +156,60 @@ class Registration(BaseModel, BasePermissionModel):
 
         if moved_registration:
             moved_registration.save()
+
+            if moved_registration.event.is_paid_event:
+                try:
+                    start_payment_countdown(
+                        moved_registration.event,
+                        moved_registration,
+                        from_wait_list=True,
+                    )
+                except Exception as countdown_error:
+                    capture_exception(countdown_error)
+                    moved_registration.delete()
+
+    def move_to_waiting_list_for_nonpayment(self):
+        """Move this registration back to the waiting list due to non-payment,
+        and promote the next eligible wait-list user."""
+        from app.content.util.event_utils import start_payment_countdown
+
+        if self.is_on_wait:
+            return
+
+        # Get next person to promote BEFORE moving self to wait list
+        moved_registration = self.move_from_waiting_list_to_queue()
+
+        # Move self back to waiting list (bottom, by resetting created_at)
+        self.is_on_wait = True
+        self.payment_expiredate = None
+        self.created_at = now()
+        self.save()
+
+        # Notify user about non-payment
+        Notify(
+            [self.user],
+            f'Betalingsfristen for "{self.event.title}" har utløpt',
+            UserNotificationSettingType.REGISTRATION,
+        ).add_paragraph(f"Hei, {self.user.first_name}!").add_paragraph(
+            "Betalingsfristen for arrangementet har utløpt uten at vi har registrert betaling. "
+            "Du har derfor blitt flyttet tilbake til ventelisten."
+        ).add_paragraph(
+            "Dersom du mener dette er feil, vennligst kontakt arrangøren."
+        ).add_event_link(self.event.pk).send()
+
+        # Promote the next person and start their payment countdown
+        if moved_registration:
+            moved_registration.save()
+            if self.event.is_paid_event:
+                try:
+                    start_payment_countdown(
+                        self.event,
+                        moved_registration,
+                        from_wait_list=True,
+                    )
+                except Exception as countdown_error:
+                    capture_exception(countdown_error)
+                    moved_registration.delete()
 
     def save(self, *args, **kwargs):
 

--- a/app/content/util/registration_utils.py
+++ b/app/content/util/registration_utils.py
@@ -1,11 +1,13 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
+
+from django.utils import timezone
 
 
 def get_payment_expiredate(event=None):
     if not event:
-        return datetime.now() + timedelta(hours=12)
+        return timezone.now() + timedelta(hours=12)
 
-    return datetime.now() + timedelta(
+    return timezone.now() + timedelta(
         hours=event.paid_information.paytime.hour,
         minutes=event.paid_information.paytime.minute,
         seconds=event.paid_information.paytime.second,

--- a/app/payment/tasks.py
+++ b/app/payment/tasks.py
@@ -1,3 +1,7 @@
+from django.utils import timezone
+
+from sentry_sdk import capture_exception
+
 from app.celery import app
 from app.content.models.event import Event
 from app.content.models.registration import Registration
@@ -14,11 +18,32 @@ def check_if_has_paid(_self, event_id, registration_id):
     if not registration or not event:
         return
 
-    user_orders = Order.objects.filter(event=event, user=registration.user)
-
-    if not user_orders:
-        registration.delete()
+    if registration.is_on_wait:
         return
 
-    if not has_paid_order(user_orders):
-        registration.delete()
+    user_orders = Order.objects.filter(event=event, user=registration.user)
+
+    if not user_orders or not has_paid_order(user_orders):
+        registration.move_to_waiting_list_for_nonpayment()
+
+
+@app.task(bind=True, base=BaseTask)
+def sweep_expired_unpaid_registrations(_self):
+    """Safety-net: find all non-wait registrations with expired payment_expiredate
+    and no paid order, and move them back to the waiting list."""
+    expired_registrations = Registration.objects.filter(
+        is_on_wait=False,
+        payment_expiredate__isnull=False,
+        payment_expiredate__lt=timezone.now(),
+        event__end_date__gt=timezone.now(),
+    )
+
+    for registration in expired_registrations:
+        user_orders = Order.objects.filter(
+            event=registration.event, user=registration.user
+        )
+        if not has_paid_order(user_orders):
+            try:
+                registration.move_to_waiting_list_for_nonpayment()
+            except Exception as e:
+                capture_exception(e)

--- a/app/payment/tests/test_payment_task.py
+++ b/app/payment/tests/test_payment_task.py
@@ -6,7 +6,7 @@ from app.content.factories import EventFactory, RegistrationFactory
 from app.content.models import Registration
 from app.payment.enums import OrderStatus
 from app.payment.factories import OrderFactory
-from app.payment.tasks import check_if_has_paid
+from app.payment.tasks import check_if_has_paid, sweep_expired_unpaid_registrations
 from app.payment.util.order_utils import check_if_order_is_paid, is_expired
 
 
@@ -21,21 +21,20 @@ def registration(event):
 
 
 @pytest.mark.django_db
-def test_delete_registration_if_no_orders(event, registration):
-    """Should delete registration if user has no orders."""
+def test_move_registration_to_waitlist_if_no_orders(event, registration):
+    """Should move registration to waiting list if user has no orders."""
 
     check_if_has_paid(event.id, registration.registration_id)
 
-    registration = Registration.objects.filter(
-        registration_id=registration.registration_id
-    ).first()
+    registration.refresh_from_db()
 
-    assert not registration
+    assert registration.is_on_wait
+    assert registration.payment_expiredate is None
 
 
 @pytest.mark.django_db
-def test_delete_registration_if_no_paid_orders(event, registration):
-    """Should delete registration if user has no paid orders."""
+def test_move_registration_to_waitlist_if_no_paid_orders(event, registration):
+    """Should move registration to waiting list if user has no paid orders."""
 
     first_order = OrderFactory(event=event, user=registration.user)
     second_order = OrderFactory(event=event, user=registration.user)
@@ -53,11 +52,37 @@ def test_delete_registration_if_no_paid_orders(event, registration):
 
     check_if_has_paid(event.id, registration.registration_id)
 
-    registration = Registration.objects.filter(
-        registration_id=registration.registration_id
-    ).first()
+    registration.refresh_from_db()
 
-    assert not registration
+    assert registration.is_on_wait
+    assert registration.payment_expiredate is None
+
+
+@pytest.mark.django_db
+def test_skip_registration_already_on_waitlist(event):
+    """Should not modify registration that is already on the waiting list."""
+
+    registration = RegistrationFactory(event=event, is_on_wait=True)
+
+    check_if_has_paid(event.id, registration.registration_id)
+
+    registration.refresh_from_db()
+
+    assert registration.is_on_wait
+
+
+@pytest.mark.django_db
+def test_move_to_waitlist_sets_created_at_to_now(event, registration):
+    """Should update created_at to now so user goes to bottom of waiting list."""
+
+    original_created_at = registration.created_at
+
+    check_if_has_paid(event.id, registration.registration_id)
+
+    registration.refresh_from_db()
+
+    assert registration.is_on_wait
+    assert registration.created_at > original_created_at
 
 
 @pytest.mark.django_db
@@ -80,6 +105,7 @@ def test_keep_registration_if_has_paid_order(event, registration):
     registration.refresh_from_db()
 
     assert registration
+    assert not registration.is_on_wait
 
 
 @pytest.mark.django_db
@@ -102,6 +128,7 @@ def test_keep_registration_if_has_reserved_order(event, registration):
     registration.refresh_from_db()
 
     assert registration
+    assert not registration.is_on_wait
 
 
 @pytest.mark.django_db
@@ -124,6 +151,7 @@ def test_keep_registration_if_has_captured_order(event, registration):
     registration.refresh_from_db()
 
     assert registration
+    assert not registration.is_on_wait
 
 
 @pytest.mark.django_db
@@ -180,3 +208,53 @@ def test_if_registration_payment_date_is_not_expired(registration):
     registration.save()
 
     assert not is_expired(registration.payment_expiredate)
+
+
+@pytest.mark.django_db
+def test_sweep_moves_expired_unpaid_registrations_to_waitlist(event):
+    """Sweep task should move expired unpaid registrations to waiting list."""
+
+    registration = RegistrationFactory(event=event, is_on_wait=False)
+    registration.payment_expiredate = timezone.now() - timezone.timedelta(hours=1)
+    registration.save()
+
+    sweep_expired_unpaid_registrations()
+
+    registration.refresh_from_db()
+
+    assert registration.is_on_wait
+    assert registration.payment_expiredate is None
+
+
+@pytest.mark.django_db
+def test_sweep_keeps_paid_registrations(event):
+    """Sweep task should not move registrations with paid orders."""
+
+    registration = RegistrationFactory(event=event, is_on_wait=False)
+    registration.payment_expiredate = timezone.now() - timezone.timedelta(hours=1)
+    registration.save()
+
+    order = OrderFactory(event=event, user=registration.user)
+    order.status = OrderStatus.SALE
+    order.save()
+
+    sweep_expired_unpaid_registrations()
+
+    registration.refresh_from_db()
+
+    assert not registration.is_on_wait
+
+
+@pytest.mark.django_db
+def test_sweep_ignores_registrations_with_future_expiry(event):
+    """Sweep task should not touch registrations whose payment window is still open."""
+
+    registration = RegistrationFactory(event=event, is_on_wait=False)
+    registration.payment_expiredate = timezone.now() + timezone.timedelta(hours=1)
+    registration.save()
+
+    sweep_expired_unpaid_registrations()
+
+    registration.refresh_from_db()
+
+    assert not registration.is_on_wait

--- a/app/payment/tests/test_payment_task.py
+++ b/app/payment/tests/test_payment_task.py
@@ -3,7 +3,6 @@ from django.utils import timezone
 import pytest
 
 from app.content.factories import EventFactory, RegistrationFactory
-from app.content.models import Registration
 from app.payment.enums import OrderStatus
 from app.payment.factories import OrderFactory
 from app.payment.tasks import check_if_has_paid, sweep_expired_unpaid_registrations


### PR DESCRIPTION
## Summary
- **Core fix:** `check_if_has_paid` celery task now moves unpaid registrations back to the waiting list (bottom) instead of deleting them, and promotes the next eligible user with a fresh payment window
- **Safety net:** Added `sweep_expired_unpaid_registrations` periodic task (every 5 min) to catch any missed expirations — prevents ghost registrations that inflate `list_count`
- **Missing countdowns:** Fixed `admin_unregister()` and `move_users_from_waiting_list_to_queue()` which promoted wait-list users on paid events without starting a payment countdown
- **Timezone fix:** `get_payment_expiredate` now uses `timezone.now()` instead of naive `datetime.now()`

## Test plan
- [x] All 19 payment task tests pass (updated existing + added new)
- [x] Full test suite passes (1418 passed, 0 failed)
- [ ] Manual: create a paid event, register, let payment expire → verify user is moved to bottom of waiting list
- [ ] Manual: verify next wait-list user gets promoted with new payment window
- [ ] Manual: verify admin unregister promotes wait-list user with payment countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)