### PR TITLE
Add suspicious payment filter and statistic for event registrations

### DIFF
--- a/app/content/filters/registration.py
+++ b/app/content/filters/registration.py
@@ -1,4 +1,4 @@
-from django.db.models import Exists, OuterRef
+from django.db.models import Count, Exists, OuterRef, Q
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import FilterSet
 
@@ -6,6 +6,7 @@ from app.common.enums import NativeGroupType as GroupType
 from app.content.models.registration import Registration
 from app.payment.enums import OrderStatus
 from app.payment.models import Order
+from app.payment.util.order_utils import PAID_ORDER_STATUSES
 
 
 class RegistrationFilter(FilterSet):
@@ -25,6 +26,10 @@ class RegistrationFilter(FilterSet):
         field_name="event__orders__status", method="filter_has_paid"
     )
 
+    has_suspicious_payment = filters.BooleanFilter(
+        method="filter_has_suspicious_payment"
+    )
+
     class Meta:
         model = Registration
         fields = [
@@ -35,6 +40,7 @@ class RegistrationFilter(FilterSet):
             "has_allergy",
             "allow_photo",
             "has_paid",
+            "has_suspicious_payment",
         ]
 
     def filter_study(self, queryset, name, value):
@@ -54,6 +60,43 @@ class RegistrationFilter(FilterSet):
             return queryset.filter(Exists(sale_order_exists))
         else:
             return queryset.exclude(Exists(sale_order_exists))
+
+    def filter_has_suspicious_payment(self, queryset, name, value):
+        paid_orders = Order.objects.filter(
+            event=OuterRef("event_id"),
+            user=OuterRef("user_id"),
+            status__in=PAID_ORDER_STATUSES,
+        )
+        usable_link = Order.objects.filter(
+            event=OuterRef("event_id"),
+            user=OuterRef("user_id"),
+            status=OrderStatus.INITIATE,
+        ).exclude(payment_link="")
+        double_paid_pairs = (
+            Order.objects.filter(status__in=PAID_ORDER_STATUSES)
+            .values("event", "user")
+            .annotate(c=Count("order_id"))
+            .filter(
+                c__gte=2,
+                event=OuterRef("event_id"),
+                user=OuterRef("user_id"),
+            )
+        )
+
+        annotated = queryset.filter(
+            event__is_paid_event=True, is_on_wait=False
+        ).annotate(
+            _double_paid=Exists(double_paid_pairs),
+            _has_paid=Exists(paid_orders),
+            _has_link=Exists(usable_link),
+        )
+        suspicious = annotated.filter(
+            Q(_double_paid=True) | (Q(_has_paid=False) & Q(_has_link=False))
+        )
+
+        if value:
+            return queryset.filter(pk__in=suspicious.values("pk"))
+        return queryset.exclude(pk__in=suspicious.values("pk"))
 
     def filter_year(self, queryset, name, value):
         return queryset.filter(

--- a/app/content/filters/registration.py
+++ b/app/content/filters/registration.py
@@ -84,7 +84,7 @@ class RegistrationFilter(FilterSet):
         )
 
         annotated = queryset.filter(
-            event__is_paid_event=True, is_on_wait=False
+            event__paid_information__isnull=False, is_on_wait=False
         ).annotate(
             _double_paid=Exists(double_paid_pairs),
             _has_paid=Exists(paid_orders),

--- a/app/content/serializers/event.py
+++ b/app/content/serializers/event.py
@@ -267,6 +267,7 @@ class EventStatisticsSerializer(BaseModelSerializer):
     has_allergy_count = serializers.SerializerMethodField()
     has_not_paid_count = serializers.SerializerMethodField()
     allow_photo_count = serializers.SerializerMethodField()
+    suspicious_payment_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
@@ -279,6 +280,7 @@ class EventStatisticsSerializer(BaseModelSerializer):
             "has_allergy_count",
             "has_not_paid_count",
             "allow_photo_count",
+            "suspicious_payment_count",
         )
 
     def get_has_attended_count(self, obj, *_args, **_kwargs):
@@ -329,3 +331,14 @@ class EventStatisticsSerializer(BaseModelSerializer):
             orders = obj.orders.filter(status=OrderStatus.SALE, event=obj).count()
             return registrations - orders
         return 0
+
+    def get_suspicious_payment_count(self, obj, *args, **kwargs):
+        if not obj.is_paid_event:
+            return 0
+        from app.payment.util.order_utils import is_suspicious_registration
+
+        return sum(
+            1
+            for registration in obj.registrations.filter(is_on_wait=False)
+            if is_suspicious_registration(registration)
+        )

--- a/app/content/serializers/registration.py
+++ b/app/content/serializers/registration.py
@@ -11,7 +11,7 @@ from app.forms.enums import NativeEventFormType as EventFormType
 from app.forms.serializers.submission import SubmissionInRegistrationSerializer
 from app.payment.enums import OrderStatus
 from app.payment.serializers.order import OrderEventRegistrationSerializer
-from app.payment.util.order_utils import has_paid_order
+from app.payment.util.order_utils import has_paid_order, is_suspicious_registration
 from app.payment.util.payment_utils import get_payment_order_status
 
 
@@ -20,6 +20,7 @@ class RegistrationSerializer(BaseModelSerializer):
     survey_submission = serializers.SerializerMethodField()
     has_unanswered_evaluation = serializers.SerializerMethodField()
     has_paid_order = serializers.SerializerMethodField(required=False)
+    has_suspicious_payment = serializers.SerializerMethodField(required=False)
     wait_queue_number = serializers.SerializerMethodField(required=False)
     payment_orders = serializers.SerializerMethodField(required=False)
 
@@ -36,6 +37,7 @@ class RegistrationSerializer(BaseModelSerializer):
             "has_unanswered_evaluation",
             "payment_expiredate",
             "has_paid_order",
+            "has_suspicious_payment",
             "wait_queue_number",
             "created_by_admin",
             "payment_orders",
@@ -57,6 +59,9 @@ class RegistrationSerializer(BaseModelSerializer):
             order.save()
 
         return has_paid_order(orders)
+
+    def get_has_suspicious_payment(self, obj):
+        return is_suspicious_registration(obj)
 
     def get_payment_orders(self, obj):
         orders = obj.event.orders.filter(user=obj.user)

--- a/app/payment/util/order_utils.py
+++ b/app/payment/util/order_utils.py
@@ -5,6 +5,8 @@ from sentry_sdk import capture_exception
 from app.payment.enums import OrderStatus
 from app.payment.util.payment_utils import get_payment_order_status
 
+PAID_ORDER_STATUSES = (OrderStatus.SALE, OrderStatus.CAPTURE, OrderStatus.RESERVED)
+
 
 def has_paid_order(orders):
     if not orders:
@@ -15,6 +17,31 @@ def has_paid_order(orders):
             return True
 
     return False
+
+
+def is_suspicious_registration(registration):
+    """A registration is suspicious when its event is paid, the user is not on
+    the waiting list, and one of:
+      (A) two or more paid orders exist for (user, event) — double-pay, or
+      (B) no paid order exists and no usable INITIATE order with a payment_link
+          exists — the Vipps button will never appear.
+    """
+    event = registration.event
+    if not event or not getattr(event, "is_paid_event", False):
+        return False
+    if registration.is_on_wait:
+        return False
+
+    orders = list(event.orders.filter(user=registration.user))
+    paid_orders = [o for o in orders if o.status in PAID_ORDER_STATUSES]
+    if len(paid_orders) >= 2:
+        return True
+    if paid_orders:
+        return False
+    has_usable_link = any(
+        o.status == OrderStatus.INITIATE and o.payment_link for o in orders
+    )
+    return not has_usable_link
 
 
 def check_if_order_is_paid(order):

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -9,6 +9,7 @@ from app.common.enums import NativeGroupType as GroupType
 from app.common.enums import NativeMembershipType as MembershipType
 from app.common.enums import NativeUserStudy as StudyType
 from app.content.factories import EventFactory, RegistrationFactory, UserFactory
+from app.content.models.registration import Registration
 from app.content.factories.priority_pool_factory import PriorityPoolFactory
 from app.forms.enums import NativeEventFormType as EventFormType
 from app.forms.tests.form_factories import EventFormFactory, SubmissionFactory
@@ -1309,3 +1310,56 @@ def test_filter_participants_paid_event(
     response = client.get(url)
     assert participant_count == response.data["count"]
     assert response.status_code == status_code
+
+
+@pytest.mark.django_db
+def test_filter_has_suspicious_payment(new_admin_user, event, paid_event):
+    """has_suspicious_payment surfaces registrations that are double-paid or
+    that have no usable Vipps payment link, and excludes normal cases."""
+    paid_event.event = event
+    paid_event.save()
+
+    double_payer = UserFactory()
+    paid_normally = UserFactory()
+    no_order = UserFactory()
+    only_cancelled = UserFactory()
+    has_usable_link = UserFactory()
+
+    RegistrationFactory(user=double_payer, event=event)
+    RegistrationFactory(user=paid_normally, event=event)
+    RegistrationFactory(user=no_order, event=event)
+    RegistrationFactory(user=only_cancelled, event=event)
+    RegistrationFactory(user=has_usable_link, event=event)
+
+    OrderFactory(event=event, user=double_payer, status=OrderStatus.SALE)
+    OrderFactory(event=event, user=double_payer, status=OrderStatus.SALE)
+    OrderFactory(event=event, user=paid_normally, status=OrderStatus.SALE)
+    OrderFactory(event=event, user=only_cancelled, status=OrderStatus.CANCEL)
+    OrderFactory(
+        event=event,
+        user=has_usable_link,
+        status=OrderStatus.INITIATE,
+        payment_link="https://pay.example/abc",
+    )
+
+    client = get_api_client(user=new_admin_user)
+
+    suspicious_url = _get_registration_url(paid_event) + "?has_suspicious_payment=true"
+    suspicious_ids = {
+        r["registration_id"] for r in client.get(suspicious_url).data["results"]
+    }
+    expected_suspicious = set(
+        Registration.objects.filter(
+            user__in=[double_payer, no_order, only_cancelled]
+        ).values_list("registration_id", flat=True)
+    )
+    assert suspicious_ids == expected_suspicious
+
+    clean_url = _get_registration_url(paid_event) + "?has_suspicious_payment=false"
+    clean_ids = {r["registration_id"] for r in client.get(clean_url).data["results"]}
+    expected_clean = set(
+        Registration.objects.filter(
+            user__in=[paid_normally, has_usable_link]
+        ).values_list("registration_id", flat=True)
+    )
+    assert clean_ids == expected_clean

--- a/app/tests/content/test_registration_integration.py
+++ b/app/tests/content/test_registration_integration.py
@@ -1313,9 +1313,15 @@ def test_filter_participants_paid_event(
 
 
 @pytest.mark.django_db
-def test_filter_has_suspicious_payment(new_admin_user, event, paid_event):
+def test_filter_has_suspicious_payment(
+    new_admin_user, event, paid_event, monkeypatch
+):
     """has_suspicious_payment surfaces registrations that are double-paid or
     that have no usable Vipps payment link, and excludes normal cases."""
+    monkeypatch.setattr(
+        "app.content.serializers.registration.get_payment_order_status",
+        lambda order_id: OrderStatus.INITIATE,
+    )
     paid_event.event = event
     paid_event.save()
 


### PR DESCRIPTION
Flags registrations on paid events as suspicious when they have 2+ paid orders (double-pay within the 5-min SALE check) or no usable Vipps payment link, exposed via has_suspicious_payment filter, an event statistics count, and a per-registration field.

## Proposed changes
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Remove this part with the description.

Issue number: closes # (remove if not an issue)


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] API docs on [Codex](https://codex.tihlde.org/contributing) have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] The fixtures have been updated if needed (for migrations)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
