### PR TITLE
feat(content): superuser export endpoint for the Photon migration

### DIFF
--- a/app/content/urls.py
+++ b/app/content/urls.py
@@ -16,6 +16,7 @@ from app.content.views import (
     UserCalendarEvents,
     UserViewSet,
     accept_form,
+    photon_user_export,
     register_with_feide,
     send_email,
 )
@@ -53,5 +54,8 @@ urlpatterns = [
     # path("delete-file/<str:container_name>/<str:blob_name>/", delete),
     path("send-email/", send_email),
     path("feide/", register_with_feide),
+    # One-time bulk user export for the Photon migration. Superuser-gated;
+    # remove once the migration is complete.
+    path("migration/photon-user-export/", photon_user_export),
     re_path(r"users/(?P<user_id>[^/.]+)/events.ics", UserCalendarEvents()),
 ]

--- a/app/content/views/__init__.py
+++ b/app/content/views/__init__.py
@@ -13,4 +13,5 @@ from app.content.views.toddel import ToddelViewSet
 from app.content.views.qr_code import QRCodeViewSet
 from app.content.views.user_bio import UserBioViewset
 from app.content.views.feide import register_with_feide
+from app.content.views.photon_user_export import photon_user_export
 from app.content.views.send_email import send_email

--- a/app/content/views/photon_user_export.py
+++ b/app/content/views/photon_user_export.py
@@ -1,0 +1,74 @@
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from app.common.permissions import is_admin_user, set_user_id
+from app.content.models import User
+
+
+@api_view(["GET"])
+def photon_user_export(request):
+    """
+    Read-only bulk export of every user, for the one-time migration to Photon
+    (the new backend). Photon has no access to this database, so it consumes
+    this endpoint instead of a direct SQL connection.
+
+    Returns only the fields Photon's user import needs. Password hashes and auth
+    tokens are deliberately left out: Photon sets its own placeholder password
+    and users authenticate via Feide afterwards, so no secret ever leaves here.
+
+    Locked to superusers who are also in HS/Index. This exposes every member's
+    name, email and bio in one response, so it should be removed once the
+    migration is done.
+
+    Header: X-Csrf-Token — the caller's auth token.
+    """
+    set_user_id(request)
+
+    if request.user is None:
+        return Response(
+            {"detail": "Manglende autentiseringsinformasjon."},
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    if not (is_admin_user(request) and request.user.is_superuser):
+        return Response(
+            {"detail": "Krever superbruker i HS/Index."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    users = (
+        User.objects.select_related("bio")
+        .order_by("created_at")
+        .values(
+            "user_id",
+            "first_name",
+            "last_name",
+            "email",
+            "gender",
+            "allergy",
+            "image",
+            "is_superuser",
+            "is_active",
+            "allows_photo_by_default",
+            "accepts_event_rules",
+            "created_at",
+            "updated_at",
+            "bio__description",
+            "bio__gitHub_link",
+            "bio__linkedIn_link",
+        )
+    )
+
+    # Flatten the bio__ prefixes into the field names Photon expects.
+    payload = [
+        {
+            **{k: v for k, v in u.items() if not k.startswith("bio__")},
+            "description": u["bio__description"],
+            "gitHub_link": u["bio__gitHub_link"],
+            "linkedIn_link": u["bio__linkedIn_link"],
+        }
+        for u in users
+    ]
+
+    return Response({"count": len(payload), "users": payload})


### PR DESCRIPTION
## Hvorfor

Photon (den nye backenden) skal migrere over alle brukere, men har **ingen tilgang til denne databasen** — verken MySQL-tilkobling eller SSH. I stedet for å åpne databasen utad, gir dette et read-only endepunkt Photon kan lese over HTTP.

## Hva

`GET /migration/photon-user-export/` returnerer alle brukere med nøyaktig de feltene Photon-importen trenger:

- `user_id`, `first_name`, `last_name`, `email`, `gender`, `allergy`, `image`
- `is_superuser`, `is_active`, `allows_photo_by_default`, `accepts_event_rules`, `created_at`, `updated_at`
- bio: `description`, `gitHub_link`, `linkedIn_link`

**Ingen hemmeligheter forlater systemet.** Passordhasher og auth-tokens er bevisst utelatt — Photon setter sitt eget plassholderpassord, og brukere logger inn via Feide etterpå.

## Sikkerhet

Låst bak `is_admin_user` (HS/Index) **og** `is_superuser`. Endepunktet eksponerer navn, e-post og bio for alle medlemmer i én respons, så det er ment å være **kortlevd** — det bør fjernes så snart migreringen er ferdig. Egen PR følger for det.

## Verifisert

- `black --check` grønt
- `flake8` grønt (F401 på barrel-`__init__.py` er allerede unntatt i `setup.cfg`)
- Feltnavn sjekket mot `User`- og `UserBio`-modellene; `created_at`/`updated_at` fra `BaseModel`
- `bio`-relasjonen (`related_name="bio"`) brukt via `select_related` — én spørring, ingen N+1

Kunne ikke kjøre full Django-test lokalt (krever Docker Compose-stacken); CI kjører den.

🤖 Generated with [Claude Code](https://claude.com/claude-code)