### PR TITLE
chore(content): sync Photon export endpoint to dev

### DIFF
--- a/app/content/urls.py
+++ b/app/content/urls.py
@@ -16,6 +16,7 @@ from app.content.views import (
     UserCalendarEvents,
     UserViewSet,
     accept_form,
+    photon_user_export,
     register_with_feide,
     send_email,
 )
@@ -53,5 +54,8 @@ urlpatterns = [
     # path("delete-file/<str:container_name>/<str:blob_name>/", delete),
     path("send-email/", send_email),
     path("feide/", register_with_feide),
+    # One-time bulk user export for the Photon migration. Superuser-gated;
+    # remove once the migration is complete.
+    path("migration/photon-user-export/", photon_user_export),
     re_path(r"users/(?P<user_id>[^/.]+)/events.ics", UserCalendarEvents()),
 ]

--- a/app/content/views/__init__.py
+++ b/app/content/views/__init__.py
@@ -13,4 +13,5 @@ from app.content.views.toddel import ToddelViewSet
 from app.content.views.qr_code import QRCodeViewSet
 from app.content.views.user_bio import UserBioViewset
 from app.content.views.feide import register_with_feide
+from app.content.views.photon_user_export import photon_user_export
 from app.content.views.send_email import send_email

--- a/app/content/views/photon_user_export.py
+++ b/app/content/views/photon_user_export.py
@@ -1,0 +1,74 @@
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from app.common.permissions import is_admin_user, set_user_id
+from app.content.models import User
+
+
+@api_view(["GET"])
+def photon_user_export(request):
+    """
+    Read-only bulk export of every user, for the one-time migration to Photon
+    (the new backend). Photon has no access to this database, so it consumes
+    this endpoint instead of a direct SQL connection.
+
+    Returns only the fields Photon's user import needs. Password hashes and auth
+    tokens are deliberately left out: Photon sets its own placeholder password
+    and users authenticate via Feide afterwards, so no secret ever leaves here.
+
+    Locked to superusers who are also in HS/Index. This exposes every member's
+    name, email and bio in one response, so it should be removed once the
+    migration is done.
+
+    Header: X-Csrf-Token — the caller's auth token.
+    """
+    set_user_id(request)
+
+    if request.user is None:
+        return Response(
+            {"detail": "Manglende autentiseringsinformasjon."},
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+
+    if not (is_admin_user(request) and request.user.is_superuser):
+        return Response(
+            {"detail": "Krever superbruker i HS/Index."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    users = (
+        User.objects.select_related("bio")
+        .order_by("created_at")
+        .values(
+            "user_id",
+            "first_name",
+            "last_name",
+            "email",
+            "gender",
+            "allergy",
+            "image",
+            "is_superuser",
+            "is_active",
+            "allows_photo_by_default",
+            "accepts_event_rules",
+            "created_at",
+            "updated_at",
+            "bio__description",
+            "bio__gitHub_link",
+            "bio__linkedIn_link",
+        )
+    )
+
+    # Flatten the bio__ prefixes into the field names Photon expects.
+    payload = [
+        {
+            **{k: v for k, v in u.items() if not k.startswith("bio__")},
+            "description": u["bio__description"],
+            "gitHub_link": u["bio__gitHub_link"],
+            "linkedIn_link": u["bio__linkedIn_link"],
+        }
+        for u in users
+    ]
+
+    return Response({"count": len(payload), "users": payload})


### PR DESCRIPTION
Bringer eksport-endepunktet fra [#998](https://github.com/TIHLDE/Lepton/pull/998) inn på `dev`.

#998 ble basert direkte på `master` for å nå prod raskt, og hoppet dermed over `dev`. `dev` hadde ikke divergert (lå bare 2 commits bak), så dette er ren synkronisering — samme commit cherry-picket, konfliktfritt.

Etter dette stemmer `dev` og `master` igjen, og feature-brancher fra `dev` får med endepunktet.

Ingen kodeendring utover det som allerede er reviewet i #998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)